### PR TITLE
alpine container image support

### DIFF
--- a/.github/workflows/update-dockerhub-docs.yml
+++ b/.github/workflows/update-dockerhub-docs.yml
@@ -26,4 +26,4 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: ${{ secrets.DOCKERHUB_REPOSITORY }}
           readme-filepath: ./dockerhub-description.md
-          short-description: 'Valkey-extension installs valkey-server and loads all the valkey modules.'
+          short-description: 'valkey-extensions installs valkey-server and loads all the valkey modules.'

--- a/00-RELEASENOTES
+++ b/00-RELEASENOTES
@@ -6,7 +6,7 @@ Valkey Extension 8.1.0-rc1 - Released Tue 1 April 2025
 ================================================================================
 Overview
 ===========================
-* valkey-extension is a containerized version of valkey, enhanced with popular modules for advanced data structures and additional search capabilities.
+* valkey-extensions is a containerized version of valkey, enhanced with popular modules for advanced data structures and additional search capabilities.
 * This image is built on top of the official valkey base image and includes pre-installed modules for simplified deployment.
 
 Core Components

--- a/8.1/alpine/Dockerfile
+++ b/8.1/alpine/Dockerfile
@@ -1,13 +1,13 @@
-{{ include ".template-helper-functions" -}}
-{{ if env.variant == "alpine" then ( -}}
-FROM docker.io/valkey/valkey:{{ ."valkey-server".version }}-alpine AS build
-{{ ) else ( -}}
-FROM docker.io/valkey/valkey:{{ ."valkey-server".version }}-bookworm AS build
-{{ ) end -}}
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
 
-ARG SERVER_VERSION={{ ."valkey-server".version }}
+FROM docker.io/valkey/valkey:8.1.0-alpine AS build
 
-{{ if env.variant == "alpine" then ( -}}
+ARG SERVER_VERSION=8.1.0
+
 RUN set -eux; \
     apk add --no-cache            \
 	        ca-certificates       \
@@ -27,28 +27,6 @@ RUN set -eux; \
 	;\
     update-ca-certificates; \
     ln -s /usr/lib/ninja-build/bin/ninja /usr/bin/ninja-build;
-{{ ) else ( -}}
-RUN set -eux;   \
-                \
-    apt-get update;     \
-    apt-get install -y --no-install-recommends  \
-                        ca-certificates         \
-                        build-essential         \
-                        cmake                   \
-                        git                     \
-                        curl                    \
-                        clang                   \
-                        clangd                  \
-                        g++                     \
-                        libgtest-dev            \
-                        ninja-build             \
-                        libssl-dev              \
-                        clang-tidy              \
-                        clang-format            \
-                        libsystemd-dev          \
-                    ;\
-    apt-get clean && rm -rf /var/lib/apt/lists/* ;
-{{ ) end -}}
 
 # Install Rust
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y;
@@ -58,18 +36,14 @@ WORKDIR /opt
 
 # Clone repositories
 RUN set -eux; \
-    git clone --depth 1 --branch {{ ."modules"."valkey-json".version }}  https://github.com/valkey-io/valkey-json.git; \
-    git clone --depth 1 --branch {{ ."modules"."valkey-bloom".version }} https://github.com/valkey-io/valkey-bloom.git; \
-{{ if env.variant == "alpine" then ( -}}
+    git clone --depth 1 --branch 1.0.0  https://github.com/valkey-io/valkey-json.git; \
+    git clone --depth 1 --branch 1.0.0 https://github.com/valkey-io/valkey-bloom.git; \
 # need to clone main on alpine until this commit is available in a release tag:
 # https://github.com/valkey-io/valkey-search/commit/eec38de7fb0423fb659b451b79a8e3420299e936
 # TODO: update this to use a release tag when available
     git clone https://github.com/valkey-io/valkey-search.git; \
     cd valkey-search; \
     git reset --hard eec38de7fb0423fb659b451b79a8e3420299e936;
-{{ ) else ( -}}
-    git clone --depth 1 --branch {{ ."modules"."valkey-search".version }} https://github.com/valkey-io/valkey-search.git;
-{{ ) end -}}
 
 # Build JSON module
 WORKDIR /opt/valkey-json
@@ -81,15 +55,10 @@ RUN set -eux; \
 
 # Build Bloom module
 WORKDIR /opt/valkey-bloom
-{{ if env.variant == "alpine" then ( -}}
 RUN RUSTFLAGS="-C target-feature=-crt-static" cargo build --all --all-targets --release;
-{{ ) else ( -}}
-RUN cargo build --all --all-targets --release;
-{{ ) end -}}
 
 # Build Search module
 WORKDIR /opt/valkey-search
-{{ if env.variant == "alpine" then ( -}}
 # on alpine, the first build fails due to this issue: https://github.com/grpc/grpc/issues/38438
 # we just replace mutable int32_t with mutable int in .build-release/.deps/grpc/third_party/re2/util/pcre.h
 # based on this upstream change https://github.com/google/re2/commit/b025c6a3ae05995660e3b882eb3277f4399ced1a
@@ -97,24 +66,12 @@ RUN set -eux;       \
     ./build.sh || true; \
     sed -i 's|^  mutable int32_t |  mutable int     |' .build-release/.deps/grpc/third_party/re2/util/pcre.h; \
     ./build.sh;
-{{ ) else ( -}}
-RUN set -eux;       \
-    ./build.sh;
-{{ ) end -}}
 
-{{ if env.variant == "alpine" then ( -}}
-FROM docker.io/valkey/valkey:{{ ."valkey-server".version }}-alpine
-{{ ) else ( -}}
-FROM docker.io/valkey/valkey:{{ ."valkey-server".version }}-bookworm
-{{ ) end -}}
+FROM docker.io/valkey/valkey:8.1.0-alpine
 
-{{ if env.variant == "alpine" then ( -}}
 RUN set -eux; \
     apk add --no-cache libstdc++; \
     mkdir -p /usr/lib/valkey;
-{{ ) else ( -}}
-RUN mkdir -p /usr/lib/valkey;
-{{ ) end -}}
 
 # Copy built modules from the build stage
 COPY --from=build /opt/valkey-json/build/src/libjson.so /usr/lib/valkey/libjson.so

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ A new Docker Image should be built and published after a new major, minor or pat
 2. Run `apply-templates.sh`
 3. Update the `dockerhub-description.md` with the updated tags.
 4. Open a new PR for the new changes.
-5. Once the PR is merged, sit back, relax and enjoy looking at your creation getting published to the official Valkey-extension Docker Hub page.
+5. Once the PR is merged, sit back, relax and enjoy looking at your creation getting published to the official valkey-extensions Docker Hub page.
 
 ## How to add a New Module?
-1. Update [versions.json](https://github.com/valkey-io/valkey-extension/blob/mainline/versions.json):
+1. Update [versions.json](https://github.com/valkey-io/valkey-extensions/blob/mainline/versions.json):
    
-   The versions.json file maintains metadata for Valkey-extension and its associated modules. To add a new module:
+   The versions.json file maintains metadata for valkey-extensions and its associated modules. To add a new module:
    - Locate the modules object: These are all modules with their respective names and versions.
     ```
         "modules": {
@@ -43,7 +43,7 @@ A new Docker Image should be built and published after a new major, minor or pat
     }
    ```
 
-2. Modify the [Dockerfile.template](https://github.com/valkey-io/valkey-extension/blob/mainline/Dockerfile.template)
+2. Modify the [Dockerfile.template](https://github.com/valkey-io/valkey-extensions/blob/mainline/Dockerfile.template)
 
   - Add dependencies: Insert the necessary dependencies to download, build, and install your new module. For example:
     ```
@@ -62,7 +62,7 @@ A new Docker Image should be built and published after a new major, minor or pat
     ```
 
   - Add the clone steps for the new module
-    Locate the [Clone repositories](https://github.com/valkey-io/valkey-extension/blob/88722ae5568792c8751b017907c95cb4a8fe1a4d/Dockerfile.template#L33) section in the Dockerfile with similar module blocks and add your module in the same pattern like:
+    Locate the [Clone repositories](https://github.com/valkey-io/valkey-extensions/blob/88722ae5568792c8751b017907c95cb4a8fe1a4d/Dockerfile.template#L33) section in the Dockerfile with similar module blocks and add your module in the same pattern like:
     ```
      # Clone repositories
     RUN set -eux; \
@@ -83,7 +83,7 @@ A new Docker Image should be built and published after a new major, minor or pat
     This also helps to track the build changes that may take place in the new versions of the modules.
 
   - Add the step to copy the module binary to `/usr/lib/valkey/`
-    Locate the [Copy built modules](https://github.com/valkey-io/valkey-extension/blob/88722ae5568792c8751b017907c95cb4a8fe1a4d/Dockerfile.template#L60C1-L60C21) sections and add a step line for the new module like:
+    Locate the [Copy built modules](https://github.com/valkey-io/valkey-extensions/blob/88722ae5568792c8751b017907c95cb4a8fe1a4d/Dockerfile.template#L60C1-L60C21) sections and add a step line for the new module like:
     ```
     COPY --from=build /opt/valkey-json/build/src/libjson.so /usr/lib/valkey/libjson.so
     COPY --from=build /opt/valkey-bloom/target/release/libvalkey_bloom.so /usr/lib/valkey/libvalkey_bloom.so
@@ -91,7 +91,7 @@ A new Docker Image should be built and published after a new major, minor or pat
     ```
 
   - Add the new module to be loaded on `valkey-server` start up
-    Locate the [`valkey-server`](https://github.com/valkey-io/valkey-extension/blob/88722ae5568792c8751b017907c95cb4a8fe1a4d/Dockerfile.template#L65) command and add the new module binary to be loaded on the server:
+    Locate the [`valkey-server`](https://github.com/valkey-io/valkey-extensions/blob/88722ae5568792c8751b017907c95cb4a8fe1a4d/Dockerfile.template#L65) command and add the new module binary to be loaded on the server:
     ```
     CMD ["valkey-server",                                               \
             "--loadmodule", "/usr/lib/valkey/libjson.so",           \
@@ -102,7 +102,7 @@ A new Docker Image should be built and published after a new major, minor or pat
 
 3. Rebuild and Publish
    Now follow the [Build and Publish](#how-do-you-build-and-publish-new-version-of-a-docker-image) steps above.
-   - Run [./apply-templates.sh](https://github.com/valkey-io/valkey-extension/blob/mainline/apply-templates.sh)
+   - Run [./apply-templates.sh](https://github.com/valkey-io/valkey-extensions/blob/mainline/apply-templates.sh)
    - Test the build
    - Open a pull request
 

--- a/apply-templates.sh
+++ b/apply-templates.sh
@@ -45,19 +45,21 @@ generated_warning() {
 for version; do
 	rm -rf "$version"
 
-	variant="debian"
+	for variant in debian alpine; do
 
-	export version variant
+		export version variant
 
-	dir="$version/$variant"
+		dir="$version/$variant"
 
-	echo "processing $dir ..."
+		echo "processing $dir ..."
 
-	mkdir -p "$dir"
+		mkdir -p "$dir"
 
-	{
-		generated_warning
-		gawk -f "$jqt" Dockerfile.template
-	} > "$dir/Dockerfile"
+		{
+			generated_warning
+			gawk -f "$jqt" Dockerfile.template
+		} > "$dir/Dockerfile"
+
+	done
 
 done

--- a/dockerhub-description.md
+++ b/dockerhub-description.md
@@ -10,6 +10,7 @@
 
 ## Release candidates
 - [`8.1.0-rc1`, `8.1`, `8`, `latest`, `8.1.0-rc1-bookworm`, `8.1-bookworm`, `8-bookworm`, `bookworm`](https://github.com/valkey-io/valkey-extensions/blob/mainline/8.1/debian/Dockerfile)
+- [`8.1.0-rc1-alpine`, `8.1-alpine`, `8-alpine`, `alpine`](https://github.com/valkey-io/valkey-extensions/blob/mainline/8.1/alpine/Dockerfile)
 
 ## What is [Valkey Extensions](https://github.com/valkey-io/valkey-extensions)?
 --------------
@@ -88,6 +89,14 @@ This is the primary image, which includes Valkey along with common modules like 
 Some of the tags may include names like `bookworm`, which refer to [Debian release codenames](https://wiki.debian.org/DebianReleases). These indicate the base image used and help ensure compatibility if your container needs additional packages. Specifying these explicitly is recommended to avoid unexpected changes when base image versions update.
 
 If you want a minimal yet functional Valkey container with built-in modules, this image is a great place to start.
+
+## `valkey/valkey-extensions:<version>-alpine`
+
+This image is based on the popular [Alpine Linux project](https://alpinelinux.org), available in [the `alpine` official image](https://hub.docker.com/_/alpine). Alpine Linux is much smaller than most distribution base images (~5MB), and thus leads to much slimmer images in general.
+
+This variant is useful when final image size being as small as possible is your primary concern. The main caveat to note is that it does use [musl libc](https://musl.libc.org) instead of [glibc and friends](https://www.etalabs.net/compare_libcs.html), so software will often run into issues depending on the depth of their libc requirements/assumptions. See [this Hacker News comment thread](https://news.ycombinator.com/item?id=10782897) for more discussion of the issues that might arise and some pro/con comparisons of using Alpine-based images.
+
+To minimize image size, it's uncommon for additional related tools (such as `git` or `bash`) to be included in Alpine-based images. Using this image as a base, add the things you need in your own Dockerfile (see the [`alpine` image description](https://hub.docker.com/_/alpine/) for examples of how to install packages if you are unfamiliar).
 
 # License
 

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -74,7 +74,7 @@ for version; do
 		${aliases[$version]:-}
 	)
 
-	for variant in debian; do
+	for variant in debian alpine; do
 		export variant
 		dir="$version/$variant"
 


### PR DESCRIPTION
This PR implements support for building a valkey-extension container image using the valkey alpine image as base.

In order to get building for Alpine working, three workarounds had to be implemented:

* Rust/cargo requires `RUSTFLAGS="-C target-feature=-crt-static"` for building on Alpine
* `valkey-search` is currently being cloned using the default branch rather than the versioned tag since the current latest versioned tag does not include [the commit that removes the systemd requirement](https://github.com/valkey-io/valkey-search/commit/eec38de7fb0423fb659b451b79a8e3420299e936) - This workaround should be removed once a new release tag has been cut in the upstream repository.
* The version of the `re2` library required through `grpc` from the `valkey-search` source requires a patch based on [this upstream commit](https://github.com/google/re2/commit/b025c6a3ae05995660e3b882eb3277f4399ced1a) until `grpc` [finalizes their currently work-in-progress upgrade to a newer `re2` version](https://github.com/grpc/grpc/pull/37938)