### PR TITLE
Adds the infra in Workflow to publish alpine images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Use imagetools to combine the arch-specific digests into one multi-arch manifest
+      # Use imagetools to combine the arch-specific digests into respective multi-arch manifest
       - name: Create Multi-Arch Manifest and Push
         working-directory: ${{ runner.temp }}/digests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,11 +154,6 @@ jobs:
           path: ${{ runner.temp }}/digests/alpine
           pattern: digests-alpine-*
           merge-multiple: true
-      
-      - name: List downloaded digests
-        run: |
-          # List all downloaded digests
-          ls -l ${{ runner.temp }}/digests
 
       - name: Download Tags
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,16 +107,24 @@ jobs:
 
       # Export digest to a file to reference it later in merging manifests
       - name: Export digest
+        id: export-digest
         run: |
           mkdir -p ${{ runner.temp }}/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
-
+      
+          # Check if the version directory contains 'debian'
+          if [[ "${{ matrix.version.meta.entries[0].directory }}" == *"debian"* ]]; then
+            echo "linux_distro=bookworm" >> "$GITHUB_OUTPUT"
+          else
+            echo "linux_distro=alpine" >> "$GITHUB_OUTPUT"
+          fi
+    
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ env.PLATFORM_PAIR }}-${{ matrix.version.name }}
-          path: ${{ runner.temp }}/digests/${{ matrix.version.meta.entries[0].directory }}/*
+          name: digests-${{ steps.export-digest.outputs.linux_distro }}-${{ env.PLATFORM_PAIR }}-${{ matrix.version.name }}
+          path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
 
@@ -133,10 +141,18 @@ jobs:
             echo "DOCKER_REPO_NAME=${{ secrets.DOCKERHUB_ACCOUNT }}/valkey-extensions" >> $GITHUB_ENV
           fi
 
-      - name: Download Digests
+      - name: Download Bookworm Digests
         uses: actions/download-artifact@v4
         with:
-          path: ${{ runner.temp }}/digests
+          path: ${{ runner.temp }}/digests/bookworm
+          pattern: digests-bookworm-*
+          merge-multiple: true
+
+      - name: Download Alpine Digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests/alpine
+          pattern: digests-alpine-*
           merge-multiple: true
       
       - name: List downloaded digests
@@ -166,17 +182,40 @@ jobs:
       - name: Create Multi-Arch Manifest and Push
         working-directory: ${{ runner.temp }}/digests
         run: |
-          # Prepare tags argument for bookworm and alpine separately from downloaded tags artifact
-          TAGS_bookworm=$(sed 's/,/ /g' ${{ runner.temp }}/tags/*.txt| grep -v "alpine" | xargs -n1 echo "-t" | tr '\n' ' ')
-          TAGS_alpine=$(sed 's/,/ /g' ${{ runner.temp }}/tags/*.txt| grep "alpine" | xargs -n1 echo "-t" | tr '\n' ' ')
+          bookworm_exists=$([ -n "$(sed 's/,/ /g' ${{ runner.temp }}/tags/*.txt | grep -v "alpine")" ] && echo "true" || echo "false")
 
-          # Construct image digest references
-          DIGESTS=$(printf '${{ env.DOCKER_REPO_NAME }}@sha256:%s ' $(ls | grep -v "alpine")))
-          # Create and push the multi-architecture manifest only for push events
-          if [[ "${{ env.IS_PULL }}" == "true" ]]; then
-            echo "Dry run: docker buildx imagetools create $TAGS $DIGESTS"
+          # Check if bookworm_exists is true
+          if [[ $bookworm_exists == "true" ]]; then
+            # Prepare tags and digest references argument for BOOKWORM from downloaded tags artifact
+            TAGS_bookworm=$(sed 's/,/ /g' ${{ runner.temp }}/tags/*.txt | grep -v "alpine" | xargs -n1 echo "-t" | tr '\n' ' ')
+            DIGESTS_bookworm=$(printf '${{ env.DOCKER_REPO_NAME }}@sha256:%s ' ./bookworm/* | sed 's|./bookworm/||g')
+
+            # Create and push the multi-architecture manifest for BOOKWORM only for push events
+            if [[ "${{ env.IS_PULL }}" == "true" ]]; then
+              echo "Dry run: docker buildx imagetools create $TAGS_bookworm $DIGESTS_bookworm"
+            else
+              docker buildx imagetools create $TAGS_bookworm $DIGESTS_bookworm
+            fi
           else
-            docker buildx imagetools create $TAGS $DIGESTS
+            echo "No valid bookworm tags found, skipping bookworm manifest creation."
+          fi
+
+          alpine_exists=$([ -n "$(sed 's/,/ /g' ${{ runner.temp }}/tags/*.txt | grep "alpine")" ] && echo "true" || echo "false")
+          
+          # Check if TAGS_alpine and DIGESTS_alpine are not empty
+          if [[ $alpine_exists == "true" ]]; then
+            # Prepare tags and digest references argument for ALPINE from downloaded tags artifact
+            TAGS_alpine=$(sed 's/,/ /g' ${{ runner.temp }}/tags/*.txt | grep "alpine" | xargs -n1 echo "-t" | tr '\n' ' ')
+            DIGESTS_alpine=$(printf '${{ env.DOCKER_REPO_NAME }}@sha256:%s ' ./alpine/* | sed 's|./alpine/||g')
+
+            # Create and push the multi-architecture manifest for ALPINE only for push events
+            if [[ "${{ env.IS_PULL }}" == "true" ]]; then
+              echo "Dry run: docker buildx imagetools create $TAGS_alpine $DIGESTS_alpine"
+            else
+              docker buildx imagetools create $TAGS_alpine $DIGESTS_alpine
+            fi
+          else
+            echo "No valid alpine tags found, skipping alpine manifest creation."
           fi
 
   update-dockerhub-description:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,8 @@ jobs:
         with:
           path: ${{ runner.temp }}/digests
           merge-multiple: true
+      
+      - name: List downloaded digests
         run: |
           # List all downloaded digests
           ls -l ${{ runner.temp }}/digests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: digests-${{ env.PLATFORM_PAIR }}-${{ matrix.version.name }}
-          path: ${{ runner.temp }}/digests/*
+          path: ${{ runner.temp }}/digests/${{ matrix.version.meta.entries[0].directory }}/*
           if-no-files-found: error
           retention-days: 1
 
@@ -137,8 +137,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: ${{ runner.temp }}/digests
-          pattern: digests-*
           merge-multiple: true
+        run: |
+          # List all downloaded digests
+          ls -l ${{ runner.temp }}/digests
 
       - name: Download Tags
         uses: actions/download-artifact@v4
@@ -162,10 +164,12 @@ jobs:
       - name: Create Multi-Arch Manifest and Push
         working-directory: ${{ runner.temp }}/digests
         run: |
-          # Prepare tags argument from downloaded tags artifact
-          TAGS=$(sed 's/,/ /g' ${{ runner.temp }}/tags/*.txt | xargs -n1 echo "-t" | tr '\n' ' ')
+          # Prepare tags argument for bookworm and alpine separately from downloaded tags artifact
+          TAGS_bookworm=$(sed 's/,/ /g' ${{ runner.temp }}/tags/*.txt| grep -v "alpine" | xargs -n1 echo "-t" | tr '\n' ' ')
+          TAGS_alpine=$(sed 's/,/ /g' ${{ runner.temp }}/tags/*.txt| grep "alpine" | xargs -n1 echo "-t" | tr '\n' ' ')
+
           # Construct image digest references
-          DIGESTS=$(printf '${{ env.DOCKER_REPO_NAME }}@sha256:%s ' *)
+          DIGESTS=$(printf '${{ env.DOCKER_REPO_NAME }}@sha256:%s ' $(ls | grep -v "alpine")))
           # Create and push the multi-architecture manifest only for push events
           if [[ "${{ env.IS_PULL }}" == "true" ]]; then
             echo "Dry run: docker buildx imagetools create $TAGS $DIGESTS"

--- a/8.1/debian/Dockerfile
+++ b/8.1/debian/Dockerfile
@@ -29,46 +29,42 @@ RUN set -eux;   \
                     ;\
     apt-get clean && rm -rf /var/lib/apt/lists/* ;
 
-# Install Rust
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y;
-ENV PATH="/root/.cargo/bin:${PATH}"
+# # Install Rust
+# RUN curl https://sh.rustup.rs -sSf | sh -s -- -y;
+# ENV PATH="/root/.cargo/bin:${PATH}"
 
-WORKDIR /opt
+# WORKDIR /opt
 
-# Clone repositories
-RUN set -eux; \
-    git clone --depth 1 --branch 1.0.0  https://github.com/valkey-io/valkey-json.git; \
-    git clone --depth 1 --branch 1.0.0 https://github.com/valkey-io/valkey-bloom.git; \
-    git clone --depth 1 --branch 1.0.0-rc1 https://github.com/valkey-io/valkey-search.git;
+# # Clone repositories
+# RUN set -eux; \
+#     git clone --depth 1 --branch 1.0.0  https://github.com/valkey-io/valkey-json.git; \
+#     git clone --depth 1 --branch 1.0.0 https://github.com/valkey-io/valkey-bloom.git; \
+#     git clone --depth 1 --branch 1.0.0-rc1 https://github.com/valkey-io/valkey-search.git;
 
-# Build JSON module
-WORKDIR /opt/valkey-json
-RUN set -eux; \
-    mkdir -p build; \
-    cd ./build; \
-    cmake .. -DVALKEY_VERSION=${SERVER_VERSION}; \
-    make;
+# # Build JSON module
+# WORKDIR /opt/valkey-json
+# RUN set -eux; \
+#     mkdir -p build; \
+#     cd ./build; \
+#     cmake .. -DVALKEY_VERSION=${SERVER_VERSION}; \
+#     make;
 
-# Build Bloom module
-WORKDIR /opt/valkey-bloom
-RUN cargo build --all --all-targets --release;
+# # Build Bloom module
+# WORKDIR /opt/valkey-bloom
+# RUN cargo build --all --all-targets --release;
 
-# Build Search module
-WORKDIR /opt/valkey-search
-RUN set -eux;       \
-    ./build.sh;
+# # Build Search module
+# WORKDIR /opt/valkey-search
+# RUN set -eux;       \
+#     ./build.sh;
 
 FROM docker.io/valkey/valkey:8.1.0-bookworm
 
 RUN mkdir -p /usr/lib/valkey;
 
-# Copy built modules from the build stage
-COPY --from=build /opt/valkey-json/build/src/libjson.so /usr/lib/valkey/libjson.so
-COPY --from=build /opt/valkey-bloom/target/release/libvalkey_bloom.so /usr/lib/valkey/libvalkey_bloom.so
-COPY --from=build /opt/valkey-search/.build-release/libsearch.so /usr/lib/valkey/libsearch.so
+# # Copy built modules from the build stage
+# COPY --from=build /opt/valkey-json/build/src/libjson.so /usr/lib/valkey/libjson.so
+# COPY --from=build /opt/valkey-bloom/target/release/libvalkey_bloom.so /usr/lib/valkey/libvalkey_bloom.so
+# COPY --from=build /opt/valkey-search/.build-release/libsearch.so /usr/lib/valkey/libsearch.so
 
-CMD ["valkey-server",                                               \
-            "--loadmodule", "/usr/lib/valkey/libjson.so",           \
-            "--loadmodule", "/usr/lib/valkey/libvalkey_bloom.so",   \
-            "--loadmodule", "/usr/lib/valkey/libsearch.so"          \
-    ]
+CMD ["valkey-server"]

--- a/8.1/debian/Dockerfile
+++ b/8.1/debian/Dockerfile
@@ -29,42 +29,46 @@ RUN set -eux;   \
                     ;\
     apt-get clean && rm -rf /var/lib/apt/lists/* ;
 
-# # Install Rust
-# RUN curl https://sh.rustup.rs -sSf | sh -s -- -y;
-# ENV PATH="/root/.cargo/bin:${PATH}"
+# Install Rust
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y;
+ENV PATH="/root/.cargo/bin:${PATH}"
 
-# WORKDIR /opt
+WORKDIR /opt
 
-# # Clone repositories
-# RUN set -eux; \
-#     git clone --depth 1 --branch 1.0.0  https://github.com/valkey-io/valkey-json.git; \
-#     git clone --depth 1 --branch 1.0.0 https://github.com/valkey-io/valkey-bloom.git; \
-#     git clone --depth 1 --branch 1.0.0-rc1 https://github.com/valkey-io/valkey-search.git;
+# Clone repositories
+RUN set -eux; \
+    git clone --depth 1 --branch 1.0.0  https://github.com/valkey-io/valkey-json.git; \
+    git clone --depth 1 --branch 1.0.0 https://github.com/valkey-io/valkey-bloom.git; \
+    git clone --depth 1 --branch 1.0.0-rc1 https://github.com/valkey-io/valkey-search.git;
 
-# # Build JSON module
-# WORKDIR /opt/valkey-json
-# RUN set -eux; \
-#     mkdir -p build; \
-#     cd ./build; \
-#     cmake .. -DVALKEY_VERSION=${SERVER_VERSION}; \
-#     make;
+# Build JSON module
+WORKDIR /opt/valkey-json
+RUN set -eux; \
+    mkdir -p build; \
+    cd ./build; \
+    cmake .. -DVALKEY_VERSION=${SERVER_VERSION}; \
+    make;
 
-# # Build Bloom module
-# WORKDIR /opt/valkey-bloom
-# RUN cargo build --all --all-targets --release;
+# Build Bloom module
+WORKDIR /opt/valkey-bloom
+RUN cargo build --all --all-targets --release;
 
-# # Build Search module
-# WORKDIR /opt/valkey-search
-# RUN set -eux;       \
-#     ./build.sh;
+# Build Search module
+WORKDIR /opt/valkey-search
+RUN set -eux;       \
+    ./build.sh;
 
 FROM docker.io/valkey/valkey:8.1.0-bookworm
 
 RUN mkdir -p /usr/lib/valkey;
 
-# # Copy built modules from the build stage
-# COPY --from=build /opt/valkey-json/build/src/libjson.so /usr/lib/valkey/libjson.so
-# COPY --from=build /opt/valkey-bloom/target/release/libvalkey_bloom.so /usr/lib/valkey/libvalkey_bloom.so
-# COPY --from=build /opt/valkey-search/.build-release/libsearch.so /usr/lib/valkey/libsearch.so
+# Copy built modules from the build stage
+COPY --from=build /opt/valkey-json/build/src/libjson.so /usr/lib/valkey/libjson.so
+COPY --from=build /opt/valkey-bloom/target/release/libvalkey_bloom.so /usr/lib/valkey/libvalkey_bloom.so
+COPY --from=build /opt/valkey-search/.build-release/libsearch.so /usr/lib/valkey/libsearch.so
 
-CMD ["valkey-server"]
+CMD ["valkey-server",                                               \
+            "--loadmodule", "/usr/lib/valkey/libjson.so",           \
+            "--loadmodule", "/usr/lib/valkey/libvalkey_bloom.so",   \
+            "--loadmodule", "/usr/lib/valkey/libsearch.so"          \
+    ]


### PR DESCRIPTION
Adds infra in workflows to correctly update the images for bookworm and alpine for the fix of https://github.com/valkey-io/valkey-extensions/issues/11 in https://github.com/valkey-io/valkey-extensions/pull/12

will create similar command for alpine as well:
```
docker buildx imagetools create -t ***/valkey-extensions:8.1.0-rc1 -t ***/valkey-extensions:8.1 -t ***/valkey-extensions:8 -t ***/valkey-extensions:latest -t ***/valkey-extensions:8.1.0-rc1-bookworm -t ***/valkey-extensions:8.1-bookworm -t ***/valkey-extensions:8-bookworm -t ***/valkey-extensions:bookworm ***/valkey-extensions@sha256:6a39e66772fa0645901a23aa20c94b88d45c2ac869ef3b17aa4efb02f6732407 ***/valkey-extensions@sha256:af473c7e0f54a2836c7e462e3de5c8472305fb3bb854e55c1ae74359a2a736e2
```

before this PR:

```
docker buildx imagetools create -t ***/valkey-extension:8.1.0-rc1 -t ***/valkey-extension:8.1 -t ***/valkey-extension:8 -t ***/valkey-extension:latest -t ***/valkey-extension:8.1.0-rc1-bookworm -t ***/valkey-extension:8.1-bookworm -t ***/valkey-extension:8-bookworm -t ***/valkey-extension:bookworm ***/valkey-extension@sha256:072008ad2bde402108e1b4db096ab98fc588df32e078009a334568f0c8511988 ***/valkey-extension@sha256:9bb16936f4dfbccd7df3f6cd909f5a2cd32e9243c7b2f07091f981cbde670b51
```

essentially does not change anything for bookworm