### PR TITLE
Fixed minor bug in the Valkey Bundle Automation

### DIFF
--- a/scripts/update-versions.py
+++ b/scripts/update-versions.py
@@ -73,7 +73,9 @@ def update_versions(versions_data: Dict[str, Any], component_name: str, new_vers
                     ["git", "ls-remote", "--exit-code", "--heads", "origin", "valkey-bundle-update"], stderr=subprocess.DEVNULL)
                 logging.info("PR exists — skipping bundle version bump.")
             except subprocess.CalledProcessError:
-                versions_data[new_major_minor_release]["version"] = f"{major}.{minor}.{patch + 1}"
+                # Increment bundle version, not valkey version
+                bundle_major, bundle_minor, bundle_patch, bundle_rc = parse_version(existing_bundle_version)
+                versions_data[new_major_minor_release]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch + 1}"
                 logging.info("No PR — bumped bundle version.")
         else:
             # New major/minor version

--- a/scripts/update-versions.py
+++ b/scripts/update-versions.py
@@ -73,7 +73,6 @@ def update_versions(versions_data: Dict[str, Any], component_name: str, new_vers
                     ["git", "ls-remote", "--exit-code", "--heads", "origin", "valkey-bundle-update"], stderr=subprocess.DEVNULL)
                 logging.info("PR exists — skipping bundle version bump.")
             except subprocess.CalledProcessError:
-                # Increment bundle version, not valkey version
                 bundle_major, bundle_minor, bundle_patch, bundle_rc = parse_version(existing_bundle_version)
                 versions_data[new_major_minor_release]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch + 1}"
                 logging.info("No PR — bumped bundle version.")


### PR DESCRIPTION
There was a small bug where whenever we were supposed to increment the bundle version we would take the latest valkey patch and add 1 to it. So when we released valkey version 8.1.3 the valkey bundle version would be 8.1.4 instead of 8.1.1. This PR should fix that.