### PR TITLE
Fix bug when releasing RC versions for Valkey

### DIFF
--- a/scripts/update-versions.py
+++ b/scripts/update-versions.py
@@ -83,9 +83,12 @@ def update_versions(versions_data: Dict[str, Any], component_name: str, new_vers
                     ["git", "ls-remote", "--exit-code", "--heads", "origin", "valkey-bundle-update"], stderr=subprocess.DEVNULL)
                 logging.info("PR exists — skipping bundle version bump.")
             except subprocess.CalledProcessError:
-                bundle_major, bundle_minor, bundle_patch, bundle_rc = parse_version(existing_bundle_version)
-                versions_data[new_major_minor_release]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch + 1}"
-                logging.info("No PR Exists — bumped bundle version.")
+                if rc is not None or '-rc' in existing_bundle_version:
+                    versions_data[new_major_minor_release]["version"] = new_version
+                else:
+                    bundle_major, bundle_minor, bundle_patch, bundle_rc = parse_version(existing_bundle_version)
+                    versions_data[new_major_minor_release]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch + 1}"
+                    logging.info("No PR Exists — bumped bundle version.")
         else:
             # New major/minor version
             known_modules = get_known_modules_from_versions(versions_data)


### PR DESCRIPTION
Currently the patch version for Valkey Bundle will be bumped whenever we release an RC or a GA. 

Example:

Currently the version for valkey-server as well as valkey-bundle is 9.0.0-rc1. If we release 9.0.0-rc2 the valkey-server version will be 9.0.0-rc2 but the bundle version will be 9.0.1 instead of 9.0.0-rc2. Additionally if we GA 9.0.0 the Valkey-server version will be 9.0.0 but the valkey bundle version will be 9.0.2 which isn't what we intended. The valkey bundle version in these cases should follow the server version when releasing an RC of Valkey or when we GA that RC. This PR fixes that issue.