### PR TITLE
Fix versioning scheme for RC's

### DIFF
--- a/scripts/update-versions.py
+++ b/scripts/update-versions.py
@@ -87,7 +87,7 @@ def update_versions(versions_data: Dict[str, Any], component_name: str, new_vers
                 
                 if rc is not None or bundle_rc is not None:
                     if rc is not None:
-                        versions_data[new_major_minor_release]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch + 1}-rc{rc}"
+                        versions_data[new_major_minor_release]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch}-rc{bundle_rc + 1}"
                     else:
                         versions_data[new_major_minor_release]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch}"
                 else:
@@ -147,8 +147,10 @@ def update_versions(versions_data: Dict[str, Any], component_name: str, new_vers
             bundle_major, bundle_minor, bundle_patch, bundle_rc = parse_version(current_version)
             
             if bundle_rc is not None:
-                versions_data[latest]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch + 1}-rc{bundle_rc}"
+                # For RC versions, increment RC number
+                versions_data[latest]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch}-rc{bundle_rc + 1}"
             else:
+                # For stable versions, increment patch
                 versions_data[latest]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch + 1}"
                 logging.info("Branch valkey-bundle-update not found — bumping patch version.")
         

--- a/scripts/update-versions.py
+++ b/scripts/update-versions.py
@@ -84,8 +84,15 @@ def update_versions(versions_data: Dict[str, Any], component_name: str, new_vers
                 logging.info("PR exists — skipping bundle version bump.")
             except subprocess.CalledProcessError:
                 bundle_major, bundle_minor, bundle_patch, bundle_rc = parse_version(existing_bundle_version)
-                versions_data[new_major_minor_release]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch + 1}"
-                logging.info("No PR Exists — bumped bundle version.")
+                
+                if rc is not None or bundle_rc is not None:
+                    if rc is not None:
+                        versions_data[new_major_minor_release]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch + 1}-rc{rc}"
+                    else:
+                        versions_data[new_major_minor_release]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch}"
+                else:
+                    versions_data[new_major_minor_release]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch + 1}"
+                    logging.info("No PR Exists — bumped bundle version.")
         else:
             # New major/minor version
             known_modules = get_known_modules_from_versions(versions_data)
@@ -138,8 +145,12 @@ def update_versions(versions_data: Dict[str, Any], component_name: str, new_vers
         except subprocess.CalledProcessError:
             current_version = versions_data[latest]["version"]
             bundle_major, bundle_minor, bundle_patch, bundle_rc = parse_version(current_version)
-            versions_data[latest]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch + 1}"
-            logging.info("Branch valkey-bundle-update not found — bumping patch version.")
+            
+            if bundle_rc is not None:
+                versions_data[latest]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch + 1}-rc{bundle_rc}"
+            else:
+                versions_data[latest]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch + 1}"
+                logging.info("Branch valkey-bundle-update not found — bumping patch version.")
         
         return versions_data
 


### PR DESCRIPTION
This will now handle updates that happen in between release candidate releases.

For example, previously:

Current Valkey Bundle Version -> 9.0.0-rc1
Then we release JSON 1.0.2
Valkey Server Version -> 9.0.0-rc1
Valkey Bundle Version -> 9.0.1
Then we release Valkey 9.0.0-rc2
Valkey Server Version -> 9.0.0-rc2
Valkey Bundle Version -> 9.0.0-rc2

This wasn't intended. With this change we now have

Current Valkey Bundle Version -> 9.0.0-rc1
Then we release JSON 1.0.2
Valkey Server Version -> 9.0.0-rc1
Valkey Bundle Version -> 9.0.0-rc2
Then we release Valkey 9.0.0-rc2
Valkey Server Version -> 9.0.0-rc2
Valkey Bundle Version -> 9.0.0-rc3
Then we GA Valkey 9.0.0
Valkey Server Version -> 9.0.0
Valkey Bundle Version -> 9.0.0