### PR TITLE
Automate the Alias Update in Valkey Bundle 

### DIFF
--- a/.github/workflows/update-files.yml
+++ b/.github/workflows/update-files.yml
@@ -44,11 +44,18 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           
       - name: Checkout valkey-container
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           repository: ${{ github.repository_owner }}/valkey-container
           path: valkey-container
           clean: false
+
+      - name: Checkout valkey-release-automation
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          repository: ${{ github.repository_owner }}/valkey-release-automation
+          ref: fix_docker_issue
+          path: valkey-release-automation
 
       - name: Exclude valkey-container in bundle repo
         run: |
@@ -136,6 +143,13 @@ jobs:
           rm strategy.json
           git add dockerhub-description.md
           git commit -m "Update DockerHub description for ${{ steps.process-inputs.outputs.component }} ${{ steps.process-inputs.outputs.version }}" || echo "No changes to commit"
+
+      - name: Update Bundle Alias
+        if: steps.process-inputs.outputs.component == 'valkey'
+        run: |
+          python ../valkey-release-automation/scripts/automate_alias_update.py generate-stackbrew-library.sh "${{ steps.process-inputs.outputs.version }}"
+          git add generate-stackbrew-library.sh
+          git commit -m "Update alias for valkey version ${{ steps.process-inputs.outputs.version }}" || echo "No changes to commit"
 
       - name: Update Bundle Alias
         if: steps.process-inputs.outputs.component == 'valkey'

--- a/.github/workflows/update-files.yml
+++ b/.github/workflows/update-files.yml
@@ -137,14 +137,14 @@ jobs:
           git add dockerhub-description.md
           git commit -m "Update DockerHub description for ${{ steps.process-inputs.outputs.component }} ${{ steps.process-inputs.outputs.version }}" || echo "No changes to commit"
 
-      - name: Update Bundle Aliases
+      - name: Update Bundle Alias
         if: steps.process-inputs.outputs.component == 'valkey'
         run: |
-          # Download the alias update script
+          # Download the alias update script from valkey-container
           wget https://raw.githubusercontent.com/${{ github.repository_owner }}/valkey-release-automation/fix_docker_issue/scripts/automate_alias_update.py
           python automate_alias_update.py generate-stackbrew-library.sh "${{ steps.process-inputs.outputs.version }}"
           git add generate-stackbrew-library.sh
-          git commit -m "Update alias for valkey ${{ steps.process-inputs.outputs.version }}" || echo "No changes to commit"
+          git commit -m "Update alias for valkey version ${{ steps.process-inputs.outputs.version }}" || echo "No changes to commit"
 
       - name: Push changes and update existing PR
         if: steps.check-branch.outputs.branch-exists == 'true'

--- a/.github/workflows/update-files.yml
+++ b/.github/workflows/update-files.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           repository: ${{ github.repository_owner }}/valkey-release-automation
-          ref: fix_docker_issue
+
           path: valkey-release-automation
 
       - name: Exclude valkey-container in bundle repo

--- a/.github/workflows/update-files.yml
+++ b/.github/workflows/update-files.yml
@@ -151,15 +151,6 @@ jobs:
           git add generate-stackbrew-library.sh
           git commit -m "Update alias for valkey version ${{ steps.process-inputs.outputs.version }}" || echo "No changes to commit"
 
-      - name: Update Bundle Alias
-        if: steps.process-inputs.outputs.component == 'valkey'
-        run: |
-          # Download the alias update script from valkey-container
-          wget https://raw.githubusercontent.com/${{ github.repository_owner }}/valkey-release-automation/fix_docker_issue/scripts/automate_alias_update.py
-          python automate_alias_update.py generate-stackbrew-library.sh "${{ steps.process-inputs.outputs.version }}"
-          git add generate-stackbrew-library.sh
-          git commit -m "Update alias for valkey version ${{ steps.process-inputs.outputs.version }}" || echo "No changes to commit"
-
       - name: Push changes and update existing PR
         if: steps.check-branch.outputs.branch-exists == 'true'
         env:

--- a/.github/workflows/update-files.yml
+++ b/.github/workflows/update-files.yml
@@ -87,18 +87,6 @@ jobs:
             echo "component=${{ github.event.inputs.component }}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Guard against unsupported Valkey versions
-        if: ${{ steps.process-inputs.outputs.component == 'valkey' }}
-        run: |
-          VERSION="${{ steps.process-inputs.outputs.version }}"
-          MAJOR=$(echo "$VERSION" | cut -d. -f1)
-          MINOR=$(echo "$VERSION" | cut -d. -f2)
-
-          if [ "$MAJOR" -lt 8 ] || { [ "$MAJOR" -eq 8 ] && [ "$MINOR" -lt 1 ]; }; then
-            echo "Valkey version must be >= 8.1. Current: $VERSION"
-            exit 1
-          fi
-
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -148,6 +136,15 @@ jobs:
           rm strategy.json
           git add dockerhub-description.md
           git commit -m "Update DockerHub description for ${{ steps.process-inputs.outputs.component }} ${{ steps.process-inputs.outputs.version }}" || echo "No changes to commit"
+
+      - name: Update Bundle Aliases
+        if: steps.process-inputs.outputs.component == 'valkey'
+        run: |
+          # Download the alias update script
+          wget https://raw.githubusercontent.com/${{ github.repository_owner }}/valkey-release-automation/main/scripts/automate_alias_update.py
+          python automate_alias_update.py generate-stackbrew-library.sh "${{ steps.process-inputs.outputs.version }}"
+          git add generate-stackbrew-library.sh
+          git commit -m "Update alias for valkey ${{ steps.process-inputs.outputs.version }}" || echo "No changes to commit"
 
       - name: Push changes and update existing PR
         if: steps.check-branch.outputs.branch-exists == 'true'

--- a/.github/workflows/update-files.yml
+++ b/.github/workflows/update-files.yml
@@ -141,7 +141,7 @@ jobs:
         if: steps.process-inputs.outputs.component == 'valkey'
         run: |
           # Download the alias update script
-          wget https://raw.githubusercontent.com/${{ github.repository_owner }}/valkey-release-automation/main/scripts/automate_alias_update.py
+          wget https://raw.githubusercontent.com/${{ github.repository_owner }}/valkey-release-automation/fix_docker_issue/scripts/automate_alias_update.py
           python automate_alias_update.py generate-stackbrew-library.sh "${{ steps.process-inputs.outputs.version }}"
           git add generate-stackbrew-library.sh
           git commit -m "Update alias for valkey ${{ steps.process-inputs.outputs.version }}" || echo "No changes to commit"


### PR DESCRIPTION
This PR updates the alias section in the Valkey Bundle by calling the same script we use in Valkey Container. Additionally I removed the guardrails step because we now guard against unsupported versions in the trigger itself so this step isn't necessary. 