### PR TITLE
Fixed Version Strategy in the Automation

### DIFF
--- a/.github/workflows/update-files.yml
+++ b/.github/workflows/update-files.yml
@@ -20,6 +20,8 @@ permissions:
   actions: write
   contents: write
   pull-requests: write
+  packages: write
+  id-token: write
 
 jobs:
   update-unstable:

--- a/dockerhub-description.md
+++ b/dockerhub-description.md
@@ -31,8 +31,8 @@ This image is built on top of the official Valkey base image and simplifies depl
 | valkey-bundle | valkey | valkey-json | valkey-bloom | valkey-search | valkey-ldap |
 |-------------------------|-------------|-------------|--------------|---------------|---------------|
 | unstable | unstable | [1.0.2](https://github.com/valkey-io/valkey-json/releases/tag/1.0.2)| [1.0.1](https://github.com/valkey-io/valkey-bloom/releases/tag/1.0.1)| [1.2.0-rc3](https://github.com/valkey-io/valkey-search/releases/tag/1.2.0-rc3) | [1.0.0](https://github.com/valkey-io/valkey-ldap/releases/tag/1.0.0) |
-| [9.0.1](https://github.com/valkey-io/valkey-bundle/releases/tag/9.0.1) |[9.0.3](https://github.com/valkey-io/valkey/releases/tag/9.0.3) | [1.0.2](https://github.com/valkey-io/valkey-json/releases/tag/1.0.2)| [1.0.1](https://github.com/valkey-io/valkey-bloom/releases/tag/1.0.1)| [1.0.2](https://github.com/valkey-io/valkey-search/releases/tag/1.0.2) | [1.0.0](https://github.com/valkey-io/valkey-ldap/releases/tag/1.0.0) |
-| [8.1.4](https://github.com/valkey-io/valkey-bundle/releases/tag/8.1.4) |[8.1.6](https://github.com/valkey-io/valkey/releases/tag/8.1.6) | [1.0.2](https://github.com/valkey-io/valkey-json/releases/tag/1.0.2)| [1.0.1](https://github.com/valkey-io/valkey-bloom/releases/tag/1.0.1)| [1.0.2](https://github.com/valkey-io/valkey-search/releases/tag/1.0.2) | [1.0.0](https://github.com/valkey-io/valkey-ldap/releases/tag/1.0.0) |
+| 9.0.1 |[9.0.3](https://github.com/valkey-io/valkey/releases/tag/9.0.3) | [1.0.2](https://github.com/valkey-io/valkey-json/releases/tag/1.0.2)| [1.0.1](https://github.com/valkey-io/valkey-bloom/releases/tag/1.0.1)| [1.0.2](https://github.com/valkey-io/valkey-search/releases/tag/1.0.2) | [1.0.0](https://github.com/valkey-io/valkey-ldap/releases/tag/1.0.0) |
+| 8.1.4 |[8.1.6](https://github.com/valkey-io/valkey/releases/tag/8.1.6) | [1.0.2](https://github.com/valkey-io/valkey-json/releases/tag/1.0.2)| [1.0.1](https://github.com/valkey-io/valkey-bloom/releases/tag/1.0.1)| [1.0.2](https://github.com/valkey-io/valkey-search/releases/tag/1.0.2) | [1.0.0](https://github.com/valkey-io/valkey-ldap/releases/tag/1.0.0) |
 
 
 # Security

--- a/scripts/update-dockerhub-description.py
+++ b/scripts/update-dockerhub-description.py
@@ -63,7 +63,7 @@ def get_versions_table() -> str:
         if version_key == 'unstable':
             row = f"| {bundle_version} | {valkey_version} | [{json_version}](https://github.com/valkey-io/valkey-json/releases/tag/{json_version})| [{bloom_version}](https://github.com/valkey-io/valkey-bloom/releases/tag/{bloom_version})| [{search_version}](https://github.com/valkey-io/valkey-search/releases/tag/{search_version}) | [{ldap_version}](https://github.com/valkey-io/valkey-ldap/releases/tag/{ldap_version}) |"
         else:
-            row = f"| [{bundle_version}](https://github.com/valkey-io/valkey-bundle/releases/tag/{bundle_version}) |[{valkey_version}](https://github.com/valkey-io/valkey/releases/tag/{valkey_version}) | [{json_version}](https://github.com/valkey-io/valkey-json/releases/tag/{json_version})| [{bloom_version}](https://github.com/valkey-io/valkey-bloom/releases/tag/{bloom_version})| [{search_version}](https://github.com/valkey-io/valkey-search/releases/tag/{search_version}) | [{ldap_version}](https://github.com/valkey-io/valkey-ldap/releases/tag/{ldap_version}) |"
+            row = f"| {bundle_version} |[{valkey_version}](https://github.com/valkey-io/valkey/releases/tag/{valkey_version}) | [{json_version}](https://github.com/valkey-io/valkey-json/releases/tag/{json_version})| [{bloom_version}](https://github.com/valkey-io/valkey-bloom/releases/tag/{bloom_version})| [{search_version}](https://github.com/valkey-io/valkey-search/releases/tag/{search_version}) | [{ldap_version}](https://github.com/valkey-io/valkey-ldap/releases/tag/{ldap_version}) |"
         
         table_rows.append(row)
     

--- a/scripts/update-versions.py
+++ b/scripts/update-versions.py
@@ -75,11 +75,8 @@ def update_versions(versions_data: Dict[str, Any], component_name: str, new_vers
             versions_data[new_major_minor_release]["valkey-server"]["version"] = new_version
             versions_data[new_major_minor_release]["debian"]["version"] = get_debian_version(new_version)
 
-            try:
-                subprocess.check_output(
-                    ["git", "ls-remote", "--exit-code", "--heads", "origin", "valkey-bundle-update"], stderr=subprocess.DEVNULL)
-                logging.info("There is an open PR for the branch valkey-bundle-update - bundle patch version won't be bumped.")
-            except subprocess.CalledProcessError:
+            # For backported valkey releases, always increment bundle version
+            if new_major_minor_release != latest:
                 bundle_major, bundle_minor, bundle_patch, bundle_rc = parse_version(existing_bundle_version)
                 
                 if rc is not None or bundle_rc is not None:
@@ -89,6 +86,22 @@ def update_versions(versions_data: Dict[str, Any], component_name: str, new_vers
                         versions_data[new_major_minor_release]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch}"
                 else:
                     versions_data[new_major_minor_release]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch + 1}"
+                logging.info(f"Updated backported bundle version from {existing_bundle_version} to {versions_data[new_major_minor_release]['version']}")
+            else:
+                try:
+                    subprocess.check_output(
+                        ["git", "ls-remote", "--exit-code", "--heads", "origin", "valkey-bundle-update"], stderr=subprocess.DEVNULL)
+                    logging.info("There is an open PR for the branch valkey-bundle-update - bundle patch version won't be bumped.")
+                except subprocess.CalledProcessError:
+                    bundle_major, bundle_minor, bundle_patch, bundle_rc = parse_version(existing_bundle_version)
+                    
+                    if rc is not None or bundle_rc is not None:
+                        if rc is not None:
+                            versions_data[new_major_minor_release]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch}-rc{bundle_rc + 1}"
+                        else:
+                            versions_data[new_major_minor_release]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch}"
+                    else:
+                        versions_data[new_major_minor_release]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch + 1}"
                     logging.info("There is no open PR for the branch valkey-bundle-update — bumping bundle patch version.")
         else:
             # New major/minor version
@@ -139,6 +152,35 @@ def update_versions(versions_data: Dict[str, Any], component_name: str, new_vers
                 if current_major_minor == new_major_minor_release:
                     versions_data[version_block]["modules"][module_key]["version"] = new_version
                     logging.info(f"Patch release: Updated {module_key} to {new_version} in Bundle version {version_block}")
+                    
+                    if version_block != latest:
+                        try:
+                            result = subprocess.check_output(['git', 'show', 'origin/mainline:versions.json'], text=True)
+                            mainline_versions = json.loads(result)
+                            mainline_bundle_version = mainline_versions[version_block]["version"]
+                            current_bundle_version = versions_data[version_block]["version"]
+                            
+                            if mainline_bundle_version != current_bundle_version:
+                                logging.info(f"Bundle version {version_block} already incremented from {mainline_bundle_version} to {current_bundle_version}")
+                            else:
+                                bundle_major, bundle_minor, bundle_patch, bundle_rc = parse_version(current_bundle_version)
+                                
+                                if bundle_rc is not None:
+                                    versions_data[version_block]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch}-rc{bundle_rc + 1}"
+                                else:
+                                    versions_data[version_block]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch + 1}"
+                                
+                                logging.info(f"Incremented bundle version {version_block} from {current_bundle_version} to {versions_data[version_block]['version']}")
+                        except subprocess.CalledProcessError:
+                            current_bundle_version = versions_data[version_block]["version"]
+                            bundle_major, bundle_minor, bundle_patch, bundle_rc = parse_version(current_bundle_version)
+                            
+                            if bundle_rc is not None:
+                                versions_data[version_block]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch}-rc{bundle_rc + 1}"
+                            else:
+                                versions_data[version_block]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch + 1}"
+                            
+                            logging.info(f"Incremented bundle version {version_block} from {current_bundle_version} to {versions_data[version_block]['version']}")
         else:
             # For major or minor releases we will only update latest version entry
             versions_data[latest]["modules"][module_key] = {"version": new_version}
@@ -148,16 +190,33 @@ def update_versions(versions_data: Dict[str, Any], component_name: str, new_vers
                 ["git", "ls-remote", "--exit-code", "--heads", "origin", "valkey-bundle-update"], stderr=subprocess.DEVNULL)
             logging.info("There is an open PR for the branch valkey-bundle-update - bundle patch version won't be bumped.")
         except subprocess.CalledProcessError:
-            current_version = versions_data[latest]["version"]
-            bundle_major, bundle_minor, bundle_patch, bundle_rc = parse_version(current_version)
-            
-            if bundle_rc is not None:
-                # For RC versions, increment RC number
-                versions_data[latest]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch}-rc{bundle_rc + 1}"
-            else:
-                # For stable versions, increment patch
-                versions_data[latest]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch + 1}"
-                logging.info("There is no open PR for the branch valkey-bundle-update — bumping bundle patch version.")
+            try:
+                result = subprocess.check_output(['git', 'show', 'origin/mainline:versions.json'], text=True)
+                mainline_versions = json.loads(result)
+                mainline_bundle_version = mainline_versions[latest]["version"]
+                current_version = versions_data[latest]["version"]
+                
+                if mainline_bundle_version != current_version:
+                    logging.info(f"Latest bundle version {latest} already incremented from {mainline_bundle_version} to {current_version} - skipping")
+                else:
+                    bundle_major, bundle_minor, bundle_patch, bundle_rc = parse_version(current_version)
+                    
+                    if bundle_rc is not None:
+                        versions_data[latest]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch}-rc{bundle_rc + 1}"
+                    else:
+                        versions_data[latest]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch + 1}"
+                    
+                    logging.info(f"No open PR - incremented latest bundle version from {current_version} to {versions_data[latest]['version']}.")
+            except subprocess.CalledProcessError:
+                current_version = versions_data[latest]["version"]
+                bundle_major, bundle_minor, bundle_patch, bundle_rc = parse_version(current_version)
+                
+                if bundle_rc is not None:
+                    versions_data[latest]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch}-rc{bundle_rc + 1}"
+                else:
+                    versions_data[latest]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch + 1}"
+                
+                logging.info(f"No open PR - incremented latest bundle version from {current_version} to {versions_data[latest]['version']}.")
         
         return versions_data
 

--- a/scripts/update-versions.py
+++ b/scripts/update-versions.py
@@ -103,11 +103,8 @@ def update_versions(versions_data: Dict[str, Any], component_name: str, new_vers
             versions_data[new_major_minor_release]["valkey-server"]["version"] = new_version
             versions_data[new_major_minor_release]["debian"]["version"] = get_debian_version(new_version)
 
-            try:
-                subprocess.check_output(
-                    ["git", "ls-remote", "--exit-code", "--heads", "origin", "valkey-bundle-update"], stderr=subprocess.DEVNULL)
-                logging.info("There is an open PR for the branch valkey-bundle-update - bundle patch version won't be bumped.")
-            except subprocess.CalledProcessError:
+            # For backported valkey releases, always increment bundle version
+            if new_major_minor_release != latest:
                 bundle_major, bundle_minor, bundle_patch, bundle_rc = parse_version(existing_bundle_version)
                 
                 if rc is not None or bundle_rc is not None:
@@ -117,6 +114,22 @@ def update_versions(versions_data: Dict[str, Any], component_name: str, new_vers
                         versions_data[new_major_minor_release]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch}"
                 else:
                     versions_data[new_major_minor_release]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch + 1}"
+                logging.info(f"Updated backported bundle version from {existing_bundle_version} to {versions_data[new_major_minor_release]['version']}")
+            else:
+                try:
+                    subprocess.check_output(
+                        ["git", "ls-remote", "--exit-code", "--heads", "origin", "valkey-bundle-update"], stderr=subprocess.DEVNULL)
+                    logging.info("There is an open PR for the branch valkey-bundle-update - bundle patch version won't be bumped.")
+                except subprocess.CalledProcessError:
+                    bundle_major, bundle_minor, bundle_patch, bundle_rc = parse_version(existing_bundle_version)
+                    
+                    if rc is not None or bundle_rc is not None:
+                        if rc is not None:
+                            versions_data[new_major_minor_release]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch}-rc{bundle_rc + 1}"
+                        else:
+                            versions_data[new_major_minor_release]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch}"
+                    else:
+                        versions_data[new_major_minor_release]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch + 1}"
                     logging.info("There is no open PR for the branch valkey-bundle-update — bumping bundle patch version.")
         else:
             # New major/minor version
@@ -180,6 +193,35 @@ def update_versions(versions_data: Dict[str, Any], component_name: str, new_vers
                 if current_major_minor == new_major_minor_release:
                     versions_data[version_block]["modules"][module_key]["version"] = new_version
                     logging.info(f"Patch release: Updated {module_key} to {new_version} in Bundle version {version_block}")
+                    
+                    if version_block != latest:
+                        try:
+                            result = subprocess.check_output(['git', 'show', 'origin/mainline:versions.json'], text=True)
+                            mainline_versions = json.loads(result)
+                            mainline_bundle_version = mainline_versions[version_block]["version"]
+                            current_bundle_version = versions_data[version_block]["version"]
+                            
+                            if mainline_bundle_version != current_bundle_version:
+                                logging.info(f"Bundle version {version_block} already incremented from {mainline_bundle_version} to {current_bundle_version}")
+                            else:
+                                bundle_major, bundle_minor, bundle_patch, bundle_rc = parse_version(current_bundle_version)
+                                
+                                if bundle_rc is not None:
+                                    versions_data[version_block]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch}-rc{bundle_rc + 1}"
+                                else:
+                                    versions_data[version_block]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch + 1}"
+                                
+                                logging.info(f"Incremented bundle version {version_block} from {current_bundle_version} to {versions_data[version_block]['version']}")
+                        except subprocess.CalledProcessError:
+                            current_bundle_version = versions_data[version_block]["version"]
+                            bundle_major, bundle_minor, bundle_patch, bundle_rc = parse_version(current_bundle_version)
+                            
+                            if bundle_rc is not None:
+                                versions_data[version_block]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch}-rc{bundle_rc + 1}"
+                            else:
+                                versions_data[version_block]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch + 1}"
+                            
+                            logging.info(f"Incremented bundle version {version_block} from {current_bundle_version} to {versions_data[version_block]['version']}")
         else:
             # For major or minor releases we will only update latest version entry
             versions_data[latest]["modules"][module_key] = {"version": new_version}
@@ -189,16 +231,33 @@ def update_versions(versions_data: Dict[str, Any], component_name: str, new_vers
                 ["git", "ls-remote", "--exit-code", "--heads", "origin", "valkey-bundle-update"], stderr=subprocess.DEVNULL)
             logging.info("There is an open PR for the branch valkey-bundle-update - bundle patch version won't be bumped.")
         except subprocess.CalledProcessError:
-            current_version = versions_data[latest]["version"]
-            bundle_major, bundle_minor, bundle_patch, bundle_rc = parse_version(current_version)
-            
-            if bundle_rc is not None:
-                # For RC versions, increment RC number
-                versions_data[latest]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch}-rc{bundle_rc + 1}"
-            else:
-                # For stable versions, increment patch
-                versions_data[latest]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch + 1}"
-                logging.info("There is no open PR for the branch valkey-bundle-update — bumping bundle patch version.")
+            try:
+                result = subprocess.check_output(['git', 'show', 'origin/mainline:versions.json'], text=True)
+                mainline_versions = json.loads(result)
+                mainline_bundle_version = mainline_versions[latest]["version"]
+                current_version = versions_data[latest]["version"]
+                
+                if mainline_bundle_version != current_version:
+                    logging.info(f"Latest bundle version {latest} already incremented from {mainline_bundle_version} to {current_version} - skipping")
+                else:
+                    bundle_major, bundle_minor, bundle_patch, bundle_rc = parse_version(current_version)
+                    
+                    if bundle_rc is not None:
+                        versions_data[latest]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch}-rc{bundle_rc + 1}"
+                    else:
+                        versions_data[latest]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch + 1}"
+                    
+                    logging.info(f"No open PR - incremented latest bundle version from {current_version} to {versions_data[latest]['version']}.")
+            except subprocess.CalledProcessError:
+                current_version = versions_data[latest]["version"]
+                bundle_major, bundle_minor, bundle_patch, bundle_rc = parse_version(current_version)
+                
+                if bundle_rc is not None:
+                    versions_data[latest]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch}-rc{bundle_rc + 1}"
+                else:
+                    versions_data[latest]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch + 1}"
+                
+                logging.info(f"No open PR - incremented latest bundle version from {current_version} to {versions_data[latest]['version']}.")
         
         return versions_data
 

--- a/scripts/update-versions.py
+++ b/scripts/update-versions.py
@@ -54,13 +54,14 @@ def get_debian_version(valkey_version: str) -> str:
     
     return container_versions[version_key]["debian"]["version"]
 
-def get_latest_module_release(repository: str) -> str:
-    """Use GitHub CLI to fetch the latest release tag for each module (including RCs)."""
-    result = subprocess.check_output(
-        ['gh', 'release', 'list', '--repo', repository, '--limit', '50',
-         '--json', 'tagName', '-q', '.[].tagName'],
-        text=True)
+def get_latest_module_release(repository: str, include_rc: bool = True) -> str:
+    """Use GitHub CLI to fetch the latest release tag for each module."""
+    result = subprocess.check_output(['gh', 'release', 'list', '--repo', repository, '--limit', '50', '--json', 'tagName', '-q', '.[].tagName'], text=True)
     tags = [t.lstrip('v') for t in result.strip().splitlines() if t.strip()]
+
+    if not include_rc:
+        tags = [t for t in tags if parse_version(t)[3] is None]
+
     tags.sort(key=lambda v: (parse_version(v)[:3], parse_version(v)[3] or float('inf')))
     return tags[-1]
 
@@ -89,8 +90,18 @@ def update_versions(versions_data: Dict[str, Any], component_name: str, new_vers
         if existing_entry:
             # Patch or RC update
             existing_bundle_version = versions_data[new_major_minor_release]["version"]
+            existing_valkey_version = versions_data[new_major_minor_release]["valkey-server"]["version"]
             versions_data[new_major_minor_release]["valkey-server"]["version"] = new_version
             versions_data[new_major_minor_release]["debian"]["version"] = get_debian_version(new_version)
+
+            # When valkey goes from RC to GA on the latest block, downgrade any RC modules to latest stable
+            if new_major_minor_release == latest and rc is None and parse_version(existing_valkey_version)[3] is not None:
+                known_modules = get_known_modules_from_versions(versions_data)
+                for name, repository in known_modules.items():
+                    current_module_version = versions_data[new_major_minor_release]["modules"][name]["version"]
+                    if parse_version(current_module_version)[3] is not None:
+                        stable_version = get_latest_module_release(repository, include_rc=False)
+                        versions_data[new_major_minor_release]["modules"][name]["version"] = stable_version
 
             # For backported valkey releases, always increment bundle version
             if new_major_minor_release != latest:
@@ -99,8 +110,7 @@ def update_versions(versions_data: Dict[str, Any], component_name: str, new_vers
                 logging.info(f"Updated backported bundle version from {existing_bundle_version} to {versions_data[new_major_minor_release]['version']}")
             else:
                 try:
-                    subprocess.check_output(
-                        ["git", "ls-remote", "--exit-code", "--heads", "origin", "valkey-bundle-update"], stderr=subprocess.DEVNULL)
+                    subprocess.check_output(["git", "ls-remote", "--exit-code", "--heads", "origin", "valkey-bundle-update"], stderr=subprocess.DEVNULL)
                     logging.info("There is an open PR for the branch valkey-bundle-update - bundle patch version won't be bumped.")
                 except subprocess.CalledProcessError:
                     bundle_major, bundle_minor, bundle_patch, bundle_rc = parse_version(existing_bundle_version)
@@ -209,8 +219,7 @@ def update_versions(versions_data: Dict[str, Any], component_name: str, new_vers
             versions_data[latest]["modules"][module_key] = {"version": new_version}
 
         try:
-            subprocess.check_output(
-                ["git", "ls-remote", "--exit-code", "--heads", "origin", "valkey-bundle-update"], stderr=subprocess.DEVNULL)
+            subprocess.check_output(["git", "ls-remote", "--exit-code", "--heads", "origin", "valkey-bundle-update"], stderr=subprocess.DEVNULL)
             logging.info("There is an open PR for the branch valkey-bundle-update - bundle patch version won't be bumped.")
         except subprocess.CalledProcessError:
             try:

--- a/scripts/update-versions.py
+++ b/scripts/update-versions.py
@@ -64,17 +64,6 @@ def get_latest_module_release(repository: str) -> str:
     tags.sort(key=lambda v: (parse_version(v)[:3], parse_version(v)[3] or float('inf')))
     return tags[-1]
 
-def get_latest_stable_module_release(repository: str) -> str:
-    """Use GitHub CLI to fetch the latest stable release tag for each module."""
-    result = subprocess.check_output(
-        ['gh', 'release', 'list', '--repo', repository, '--limit', '50',
-         '--json', 'tagName,isPrerelease', '-q',
-         '[.[] | select(.isPrerelease == false) | select(.tagName | test("-rc") | not)] | .[].tagName'],
-        text=True)
-    tags = [t.lstrip('v') for t in result.strip().splitlines() if t.strip()]
-    tags.sort(key=lambda v: [int(x) for x in v.split('.')])
-    return tags[-1]
-
 def update_unstable(versions_data: Dict[str, Any]) -> Dict[str, Any]:
     """Update the unstable block with latest stable module releases."""
     known_modules = get_known_modules_from_versions(versions_data)
@@ -137,7 +126,7 @@ def update_versions(versions_data: Dict[str, Any], component_name: str, new_vers
 
             module_versions = {}
             for name, repository in known_modules.items():
-                latest_version = get_latest_stable_module_release(repository)
+                latest_version = get_latest_module_release(repository)
                 module_versions[name] = {"version": latest_version}
 
             new_entry = {

--- a/scripts/update-versions.py
+++ b/scripts/update-versions.py
@@ -95,14 +95,7 @@ def update_versions(versions_data: Dict[str, Any], component_name: str, new_vers
             # For backported valkey releases, always increment bundle version
             if new_major_minor_release != latest:
                 bundle_major, bundle_minor, bundle_patch, bundle_rc = parse_version(existing_bundle_version)
-                
-                if rc is not None or bundle_rc is not None:
-                    if rc is not None:
-                        versions_data[new_major_minor_release]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch}-rc{bundle_rc + 1}"
-                    else:
-                        versions_data[new_major_minor_release]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch}"
-                else:
-                    versions_data[new_major_minor_release]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch + 1}"
+                versions_data[new_major_minor_release]["version"] = f"{bundle_major}.{bundle_minor}.{bundle_patch + 1}"
                 logging.info(f"Updated backported bundle version from {existing_bundle_version} to {versions_data[new_major_minor_release]['version']}")
             else:
                 try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,33 @@ def make_versions_data():
     }
 
 
+def make_versions_data_with_rc_latest():
+    """Versions data where the latest block is an RC with RC modules."""
+    data = make_versions_data()
+    data["9.0"]["version"] = "9.0.0-rc1"
+    data["9.0"]["valkey-server"]["version"] = "9.0.0-rc1"
+    data["9.0"]["modules"]["valkey-search"]["version"] = "1.1.0-rc1"
+    data["9.0"]["modules"]["valkey-ldap"]["version"] = "1.1.0-rc1"
+    return data
+
+
+def make_versions_data_three_blocks():
+    """Versions data with three numeric blocks for testing multi-block scenarios."""
+    data = make_versions_data()
+    data["9.1"] = {
+        "version": "9.1.0-rc1",
+        "valkey-server": {"version": "9.1.0-rc1"},
+        "modules": {
+            "valkey-json": {"version": "1.0.1"},
+            "valkey-bloom": {"version": "1.0.0"},
+            "valkey-search": {"version": "1.1.0-rc1"},
+            "valkey-ldap": {"version": "1.0.0"},
+        },
+        "debian": {"version": "bookworm"},
+    }
+    return data
+
+
 @pytest.fixture
 def versions_data():
     return make_versions_data()
@@ -54,3 +81,13 @@ def versions_data_rc():
     data["9.0"]["version"] = "9.0.1-rc2"
     data["9.0"]["valkey-server"]["version"] = "9.0.2-rc1"
     return data
+
+
+@pytest.fixture
+def versions_data_rc_latest():
+    return make_versions_data_with_rc_latest()
+
+
+@pytest.fixture
+def versions_data_three_blocks():
+    return make_versions_data_three_blocks()

--- a/tests/test_update_dockerhub_description.py
+++ b/tests/test_update_dockerhub_description.py
@@ -98,9 +98,7 @@ class TestGetVersionsTable:
         assert len(lines) == 2  # unstable + 9.0
         # unstable row should NOT have a bundle link
         assert "| unstable |" in lines[0]
-        # 9.0 row should have a bundle release link
         assert "9.0.1" in lines[1]
-        assert "valkey-bundle/releases/tag/9.0.1" in lines[1]
 
     def test_sorts_numeric_descending(self, tmp_path, monkeypatch):
         versions = {

--- a/tests/test_update_versions.py
+++ b/tests/test_update_versions.py
@@ -178,7 +178,7 @@ class TestUpdateVersionsValkey:
     def test_new_major_minor_creates_entry(self, versions_data, mocker):
         mocker.patch.object(update_versions, "get_debian_version", return_value="trixie")
         mocker.patch.object(
-            update_versions, "get_latest_stable_module_release", return_value="2.0.0"
+            update_versions, "get_latest_module_release", return_value="2.0.0"
         )
 
         result = update_versions_fn(versions_data, "valkey", "10.0.0")

--- a/tests/test_update_versions.py
+++ b/tests/test_update_versions.py
@@ -188,6 +188,74 @@ class TestUpdateVersionsValkey:
         for mod in ["valkey-json", "valkey-bloom", "valkey-search", "valkey-ldap"]:
             assert result["10.0"]["modules"][mod]["version"] == "2.0.0"
 
+    def test_new_major_minor_rc_creates_entry(self, versions_data, mocker):
+        mocker.patch.object(update_versions, "get_debian_version", return_value="trixie")
+        mocker.patch.object(update_versions, "get_latest_module_release", return_value="2.0.0-rc1")
+
+        result = update_versions_fn(versions_data, "valkey", "10.0.0-rc1")
+        assert "10.0" in result
+        assert result["10.0"]["valkey-server"]["version"] == "10.0.0-rc1"
+        assert result["10.0"]["version"] == "10.0.0-rc1"
+        for mod in ["valkey-json", "valkey-bloom", "valkey-search", "valkey-ldap"]:
+            assert result["10.0"]["modules"][mod]["version"] == "2.0.0-rc1"
+
+    def test_backported_valkey_always_bumps_bundle(self, versions_data, mocker):
+        mocker.patch.object(update_versions, "get_debian_version", return_value="bookworm")
+        result = update_versions_fn(versions_data, "valkey", "8.1.5")
+        assert result["8.1"]["valkey-server"]["version"] == "8.1.5"
+        assert result["8.1"]["version"] == "8.1.3"  # 8.1.2 -> 8.1.3
+
+    def test_backported_valkey_does_not_touch_latest(self, versions_data, mocker):
+        mocker.patch.object(update_versions, "get_debian_version", return_value="bookworm")
+        original_latest = copy.deepcopy(versions_data["9.0"])
+        update_versions_fn(versions_data, "valkey", "8.1.5")
+        assert versions_data["9.0"] == original_latest
+
+    def test_ga_downgrades_rc_modules_to_stable(self, versions_data_rc_latest, mocker):
+        mocker.patch.object(update_versions, "get_debian_version", return_value="bookworm")
+        mocker.patch.object(
+            update_versions, "get_latest_module_release",
+            side_effect=lambda repo, include_rc=True: {
+                "valkey-io/valkey-json": "1.0.1",
+                "valkey-io/valkey-bloom": "1.0.0",
+                "valkey-io/valkey-search": "1.0.1",
+                "valkey-io/valkey-ldap": "1.0.0",
+            }[repo],
+        )
+        # Simulate no open PR
+        mocker.patch("subprocess.check_output", side_effect=subprocess.CalledProcessError(1, "git"))
+
+        # 9.0 has valkey-server 9.0.0-rc1, search 1.1.0-rc1, ldap 1.1.0-rc1
+        result = update_versions_fn(versions_data_rc_latest, "valkey", "9.0.0")
+        assert result["9.0"]["valkey-server"]["version"] == "9.0.0"
+        # RC modules should be downgraded to latest stable
+        assert result["9.0"]["modules"]["valkey-search"]["version"] == "1.0.1"
+        assert result["9.0"]["modules"]["valkey-ldap"]["version"] == "1.0.0"
+        # Already-stable modules should be untouched
+        assert result["9.0"]["modules"]["valkey-json"]["version"] == "1.0.1"
+        assert result["9.0"]["modules"]["valkey-bloom"]["version"] == "1.0.0"
+
+    def test_ga_does_not_downgrade_when_no_rc_modules(self, versions_data, mocker):
+        mocker.patch.object(update_versions, "get_debian_version", return_value="bookworm")
+        mocker.patch("subprocess.check_output", side_effect=subprocess.CalledProcessError(1, "git"))
+        # Set valkey-server to RC so the GA path triggers, but all modules are stable
+        versions_data["9.0"]["valkey-server"]["version"] = "9.0.0-rc1"
+        versions_data["9.0"]["version"] = "9.0.0-rc1"
+
+        original_modules = copy.deepcopy(versions_data["9.0"]["modules"])
+        result = update_versions_fn(versions_data, "valkey", "9.0.0")
+        assert result["9.0"]["modules"] == original_modules
+
+    def test_ga_downgrade_only_on_latest_block(self, versions_data_three_blocks, mocker):
+        mocker.patch.object(update_versions, "get_debian_version", return_value="bookworm")
+        # 9.1 is latest, 8.1 has valkey-server set to RC for this test
+        versions_data_three_blocks["8.1"]["valkey-server"]["version"] = "8.1.0-rc1"
+        versions_data_three_blocks["8.1"]["modules"]["valkey-search"]["version"] = "1.1.0-rc1"
+
+        result = update_versions_fn(versions_data_three_blocks, "valkey", "8.1.0")
+        # 8.1 is not latest, so GA downgrade should NOT run — RC module stays
+        assert result["8.1"]["modules"]["valkey-search"]["version"] == "1.1.0-rc1"
+
 
 # ---------------------------------------------------------------------------
 # update_versions — module component
@@ -206,6 +274,20 @@ class TestUpdateVersionsModule:
         result = update_versions_fn(versions_data, "json", "1.0.2")
         assert result["8.1"]["modules"]["valkey-json"]["version"] == "1.0.2"
         assert result["9.0"]["modules"]["valkey-json"]["version"] == "1.0.2"
+
+    def test_module_patch_does_not_touch_unstable(self, versions_data, mocker):
+        self._no_open_pr(mocker)
+        original_unstable = copy.deepcopy(versions_data["unstable"])
+        update_versions_fn(versions_data, "json", "1.0.2")
+        assert versions_data["unstable"] == original_unstable
+
+    def test_module_patch_updates_three_blocks(self, versions_data_three_blocks, mocker):
+        self._no_open_pr(mocker)
+        # json is 1.0.1 in 8.1, 9.0, and 9.1 — patch should update all three
+        result = update_versions_fn(versions_data_three_blocks, "json", "1.0.2")
+        assert result["8.1"]["modules"]["valkey-json"]["version"] == "1.0.2"
+        assert result["9.0"]["modules"]["valkey-json"]["version"] == "1.0.2"
+        assert result["9.1"]["modules"]["valkey-json"]["version"] == "1.0.2"
 
     def test_module_patch_does_not_update_different_major_minor(self, versions_data, mocker):
         self._no_open_pr(mocker)
@@ -236,6 +318,21 @@ class TestUpdateVersionsModule:
         with pytest.raises(SystemExit):
             update_versions_fn(versions_data, "json", "1.1.0")
 
+    def test_module_minor_release_allowed_when_valkey_minor_gt_zero(self, versions_data_three_blocks, mocker):
+        self._no_open_pr(mocker)
+        # 9.1 is latest, valkey-server is 9.1.0-rc1 (minor=1), so module minor release should be allowed
+        result = update_versions_fn(versions_data_three_blocks, "json", "1.1.0")
+        assert result["9.1"]["modules"]["valkey-json"]["version"] == "1.1.0"
+        # Other blocks should be untouched
+        assert result["8.1"]["modules"]["valkey-json"]["version"] == "1.0.1"
+        assert result["9.0"]["modules"]["valkey-json"]["version"] == "1.0.1"
+
+    def test_module_major_release_allowed_with_rc_valkey(self, versions_data, mocker):
+        self._no_open_pr(mocker)
+        versions_data["9.0"]["valkey-server"]["version"] = "9.0.0-rc1"
+        result = update_versions_fn(versions_data, "json", "2.0.0")
+        assert result["9.0"]["modules"]["valkey-json"]["version"] == "2.0.0"
+
     def test_module_bumps_bundle_patch_when_no_pr(self, versions_data, mocker):
         self._no_open_pr(mocker)
 
@@ -251,3 +348,40 @@ class TestUpdateVersionsModule:
         # Use a patch release instead
         result = update_versions_fn(versions_data_rc, "json", "1.0.2")
         assert result["9.0"]["version"] == "9.0.1-rc3"
+
+    def test_module_no_bundle_bump_when_pr_exists(self, versions_data, mocker):
+        def mock_check_output(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get('args', [])
+            if cmd[0] == 'git' and 'ls-remote' in cmd:
+                return b"abc123\trefs/heads/valkey-bundle-update\n"
+            if cmd[0] == 'git' and 'show' in cmd:
+                return json.dumps(versions_data)
+            raise subprocess.CalledProcessError(1, "unknown")
+
+        mocker.patch("subprocess.check_output", side_effect=mock_check_output)
+        original_bundle = versions_data["9.0"]["version"]
+        result = update_versions_fn(versions_data, "json", "1.0.2")
+        assert result["9.0"]["version"] == original_bundle
+
+    def test_module_patch_dedup_non_latest_already_bumped(self, versions_data_three_blocks, mocker):
+        """When a non-latest block's bundle was already bumped (differs from mainline), skip the bump."""
+        def mock_check_output(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get('args', [])
+            if cmd[0] == 'git' and 'ls-remote' in cmd:
+                raise subprocess.CalledProcessError(1, "git")
+            if cmd[0] == 'git' and 'show' in cmd:
+                # Simulate mainline has 8.1 bundle at 8.1.2 (same as current)
+                # but 9.0 bundle at 9.0.0 (different from current 9.0.1 — already bumped)
+                import json
+                mainline = copy.deepcopy(versions_data_three_blocks)
+                mainline["9.0"]["version"] = "9.0.0"
+                return json.dumps(mainline)
+            raise subprocess.CalledProcessError(1, "unknown")
+
+        mocker.patch("subprocess.check_output", side_effect=mock_check_output)
+
+        result = update_versions_fn(versions_data_three_blocks, "json", "1.0.2")
+        # 8.1 should bump (mainline matches current)
+        assert result["8.1"]["version"] == "8.1.3"
+        # 9.0 should NOT bump (mainline differs — already bumped)
+        assert result["9.0"]["version"] == "9.0.1"


### PR DESCRIPTION
Resolves #78 

**Changes Made**

- When we release backported version of valkey-server we will always increment the valkey-bundle version for that specific version block. Backported versions also won't have RC's so I removed that check.
- When we release patch versions for the modules we will increment the valkey-bundle version for all older version blocks. We need to check against mainline to see if we already updated it locally so we don't update the bundle version twice (in case we release two backported module versions in the same PR)
- New version blocks should pull the latest module version instead of the latest stable version (So we can pull RC instead of GA). If we GA a Valkey version we will check to see if any of the modules is in an RC state. If so we will pull the latest stable version of that module instead.
- Get rid of links to the tags in the Docker Hub Description
- Add missing permissions so CI is triggered. Failure yesterday: https://github.com/valkey-io/valkey-bundle/actions/runs/23328167353
