### PR TITLE
Fix bundle-docker-entrypoint.sh loadmodule twice

### DIFF
--- a/8.1/alpine/bundle-docker-entrypoint.sh
+++ b/8.1/alpine/bundle-docker-entrypoint.sh
@@ -5,10 +5,12 @@ MODULE_DIR="/usr/lib/valkey"
 MODULE_ARGS=""
 CONFIG=""
 
-# Check if the first arg is a config file (`something.conf`)
-if [ "${1%.conf}" != "$1" ]; then
-    CONFIG="${1}"
-fi 
+# Check if the arguments list have a config file (`something.conf`)
+for arg in "${@}"; do
+    if [ "${arg%.conf}" != "$arg" ]; then
+        CONFIG="${arg}"
+    fi 
+done
 
 # Auto-discover and append all .so modules in MODULE_DIR
 for module in "$MODULE_DIR"/*.so; do

--- a/8.1/alpine/bundle-docker-entrypoint.sh
+++ b/8.1/alpine/bundle-docker-entrypoint.sh
@@ -3,9 +3,19 @@ set -e
 
 MODULE_DIR="/usr/lib/valkey"
 MODULE_ARGS=""
+CONFIG=""
+
+# Check if the first arg is a config file (`something.conf`)
+if [ "${1%.conf}" != "$1" ]; then
+    CONFIG="${1}"
+fi 
 
 # Auto-discover and append all .so modules in MODULE_DIR
 for module in "$MODULE_DIR"/*.so; do
+    if [ -n "$(grep "loadmodule $module" "${CONFIG}")" ]; then 
+        # skipping `loadmodule` flag due to being already present in config file
+        continue
+    fi 
     if [ -f "$module" ]; then
         MODULE_ARGS="$MODULE_ARGS --loadmodule $module"
     fi

--- a/8.1/debian/bundle-docker-entrypoint.sh
+++ b/8.1/debian/bundle-docker-entrypoint.sh
@@ -5,10 +5,12 @@ MODULE_DIR="/usr/lib/valkey"
 MODULE_ARGS=""
 CONFIG=""
 
-# Check if the first arg is a config file (`something.conf`)
-if [ "${1%.conf}" != "$1" ]; then
-    CONFIG="${1}"
-fi 
+# Check if the arguments list have a config file (`something.conf`)
+for arg in "${@}"; do
+    if [ "${arg%.conf}" != "$arg" ]; then
+        CONFIG="${arg}"
+    fi 
+done
 
 # Auto-discover and append all .so modules in MODULE_DIR
 for module in "$MODULE_DIR"/*.so; do

--- a/8.1/debian/bundle-docker-entrypoint.sh
+++ b/8.1/debian/bundle-docker-entrypoint.sh
@@ -3,9 +3,19 @@ set -e
 
 MODULE_DIR="/usr/lib/valkey"
 MODULE_ARGS=""
+CONFIG=""
+
+# Check if the first arg is a config file (`something.conf`)
+if [ "${1%.conf}" != "$1" ]; then
+    CONFIG="${1}"
+fi 
 
 # Auto-discover and append all .so modules in MODULE_DIR
 for module in "$MODULE_DIR"/*.so; do
+    if [ -n "$(grep "loadmodule $module" "${CONFIG}")" ]; then 
+        # skipping `loadmodule` flag due to being already present in config file
+        continue
+    fi 
     if [ -f "$module" ]; then
         MODULE_ARGS="$MODULE_ARGS --loadmodule $module"
     fi

--- a/9.0/alpine/bundle-docker-entrypoint.sh
+++ b/9.0/alpine/bundle-docker-entrypoint.sh
@@ -5,10 +5,12 @@ MODULE_DIR="/usr/lib/valkey"
 MODULE_ARGS=""
 CONFIG=""
 
-# Check if the first arg is a config file (`something.conf`)
-if [ "${1%.conf}" != "$1" ]; then
-    CONFIG="${1}"
-fi 
+# Check if the arguments list have a config file (`something.conf`)
+for arg in "${@}"; do
+    if [ "${arg%.conf}" != "$arg" ]; then
+        CONFIG="${arg}"
+    fi 
+done
 
 # Auto-discover and append all .so modules in MODULE_DIR
 for module in "$MODULE_DIR"/*.so; do

--- a/9.0/alpine/bundle-docker-entrypoint.sh
+++ b/9.0/alpine/bundle-docker-entrypoint.sh
@@ -3,9 +3,19 @@ set -e
 
 MODULE_DIR="/usr/lib/valkey"
 MODULE_ARGS=""
+CONFIG=""
+
+# Check if the first arg is a config file (`something.conf`)
+if [ "${1%.conf}" != "$1" ]; then
+    CONFIG="${1}"
+fi 
 
 # Auto-discover and append all .so modules in MODULE_DIR
 for module in "$MODULE_DIR"/*.so; do
+    if [ -n "$(grep "loadmodule $module" "${CONFIG}")" ]; then 
+        # skipping `loadmodule` flag due to being already present in config file
+        continue
+    fi 
     if [ -f "$module" ]; then
         MODULE_ARGS="$MODULE_ARGS --loadmodule $module"
     fi

--- a/9.0/debian/bundle-docker-entrypoint.sh
+++ b/9.0/debian/bundle-docker-entrypoint.sh
@@ -5,10 +5,12 @@ MODULE_DIR="/usr/lib/valkey"
 MODULE_ARGS=""
 CONFIG=""
 
-# Check if the first arg is a config file (`something.conf`)
-if [ "${1%.conf}" != "$1" ]; then
-    CONFIG="${1}"
-fi 
+# Check if the arguments list have a config file (`something.conf`)
+for arg in "${@}"; do
+    if [ "${arg%.conf}" != "$arg" ]; then
+        CONFIG="${arg}"
+    fi 
+done
 
 # Auto-discover and append all .so modules in MODULE_DIR
 for module in "$MODULE_DIR"/*.so; do

--- a/9.0/debian/bundle-docker-entrypoint.sh
+++ b/9.0/debian/bundle-docker-entrypoint.sh
@@ -3,9 +3,19 @@ set -e
 
 MODULE_DIR="/usr/lib/valkey"
 MODULE_ARGS=""
+CONFIG=""
+
+# Check if the first arg is a config file (`something.conf`)
+if [ "${1%.conf}" != "$1" ]; then
+    CONFIG="${1}"
+fi 
 
 # Auto-discover and append all .so modules in MODULE_DIR
 for module in "$MODULE_DIR"/*.so; do
+    if [ -n "$(grep "loadmodule $module" "${CONFIG}")" ]; then 
+        # skipping `loadmodule` flag due to being already present in config file
+        continue
+    fi 
     if [ -f "$module" ]; then
         MODULE_ARGS="$MODULE_ARGS --loadmodule $module"
     fi

--- a/bundle-docker-entrypoint.sh
+++ b/bundle-docker-entrypoint.sh
@@ -3,9 +3,21 @@ set -e
 
 MODULE_DIR="/usr/lib/valkey"
 MODULE_ARGS=""
+CONFIG=""
+
+# Check if the arguments list have a config file (`something.conf`)
+for arg in "${@}"; do
+    if [ "${arg%.conf}" != "$arg" ]; then
+        CONFIG="${arg}"
+    fi 
+done
 
 # Auto-discover and append all .so modules in MODULE_DIR
 for module in "$MODULE_DIR"/*.so; do
+    if [ -n "$(grep "loadmodule $module" "${CONFIG}")" ]; then 
+        # skipping `loadmodule` flag due to being already present in config file
+        continue
+    fi 
     if [ -f "$module" ]; then
         MODULE_ARGS="$MODULE_ARGS --loadmodule $module"
     fi


### PR DESCRIPTION
If valkey container is started with a config file, the current `bundle-docker-entrypoint.sh` script will still generate the valkey-server command with `--loadmodule` flag.
If a `CONFIG REWRITE` is issued (for example, by Sentinel client), the loadmodule entries will be written to the config file. Restarting the container will result in a module initialization error (because modules are loaded twice).

This PR adds a check to skip the `--loadmodule` flag if the container is started with a config file, and the `loadmodule $module` entry is already present.