### PR TITLE
Only Update Module Minor Versions when Valkey is at a Minor Version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,10 +79,13 @@ jobs:
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
+      - name: Set lowercase actor name
+        run: echo "ACTOR_LOWER=$(echo '${{ github.actor }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       - name: Set DOCKER_REPO_NAME dynamically
         run: |
           if [[ "${{ env.IS_PULL }}" == "true" || "${{ env.HAS_SECRETS }}" != "true" ]]; then
-            echo "DOCKER_REPO_NAME=${{ github.actor }}/valkey-bundle" >> $GITHUB_ENV
+            echo "DOCKER_REPO_NAME=${{ env.ACTOR_LOWER }}/valkey-bundle" >> $GITHUB_ENV
           else
             echo "DOCKER_REPO_NAME=${{ secrets.DOCKERHUB_ACCOUNT }}/valkey-bundle" >> $GITHUB_ENV
           fi
@@ -90,7 +93,7 @@ jobs:
       - name: Set GHCR_REPO_NAME dynamically
         run: |
           if [[ "${{ env.IS_PULL }}" == "true" || "${{ env.HAS_SECRETS }}" != "true" ]]; then
-            echo "GHCR_REPO_NAME=${{ github.actor }}/valkey-bundle" >> $GITHUB_ENV
+            echo "GHCR_REPO_NAME=${{ env.ACTOR_LOWER }}/valkey-bundle" >> $GITHUB_ENV
           else
             echo "GHCR_REPO_NAME=${{ github.repository_owner }}/valkey-bundle" >> $GITHUB_ENV
           fi
@@ -98,7 +101,7 @@ jobs:
       - name: Set ECR_REPO_PATH dynamically
         run: |
           if [[ "${{ env.IS_PULL }}" == "true" || "${{ env.HAS_SECRETS }}" != "true" ]]; then
-            echo "ECR_REPO_PATH=${{ github.actor }}/valkey-bundle" >> $GITHUB_ENV
+            echo "ECR_REPO_PATH=${{ env.ACTOR_LOWER }}/valkey-bundle" >> $GITHUB_ENV
           else
             echo "ECR_REPO_PATH=${{ secrets.ECR_REGISTRY_ALIAS }}/valkey-bundle" >> $GITHUB_ENV
           fi

--- a/scripts/update-versions.py
+++ b/scripts/update-versions.py
@@ -129,16 +129,16 @@ def update_versions(versions_data: Dict[str, Any], component_name: str, new_vers
                     f"Can't release {component_name} {new_version}: "
                     f"The latest Valkey version is '{valkey_version}', which is not a new major version release (X.0.0 or X.0.0-rcY)."
                 )
-                sys.exit(1)
+                sys.exit(0)
         
-        # Only update module minor versions if Valkey is also at a minor version
+        # Skip the automation process if we release a minor version for a module
         is_module_minor_release = (minor > 0 and patch == 0)
         if is_module_minor_release and valkey_minor == 0:
             logging.error(
                 f"Can't release {component_name} {new_version}: "
                 f"The latest Valkey version is '{valkey_version}', which is not a minor version release."
             )
-            sys.exit(1)
+            sys.exit(0)
         
         if patch > 0:
             # For patch releases we will update all version entries with the same major.minor version as the module patch we just released

--- a/scripts/update-versions.py
+++ b/scripts/update-versions.py
@@ -120,14 +120,25 @@ def update_versions(versions_data: Dict[str, Any], component_name: str, new_vers
 
         is_module_major_release = (minor == 0 and patch == 0)
 
+        valkey_version = versions_data[latest]["valkey-server"]["version"]
+        valkey_major, valkey_minor, valkey_patch, valkey_rc = parse_version(valkey_version)
+        
         if is_module_major_release:
-            valkey_version = versions_data[latest]["valkey-server"]["version"]
             if not re.match(r'^\d+\.0\.0(?:-rc\d+)?$', valkey_version):
                 logging.error(
                     f"Can't release {component_name} {new_version}: "
                     f"The latest Valkey version is '{valkey_version}', which is not a new major version release (X.0.0 or X.0.0-rcY)."
                 )
                 sys.exit(1)
+        
+        # Only update module minor versions if Valkey is also at a minor version
+        is_module_minor_release = (minor > 0 and patch == 0)
+        if is_module_minor_release and valkey_minor == 0:
+            logging.error(
+                f"Can't release {component_name} {new_version}: "
+                f"The latest Valkey version is '{valkey_version}', which is not a minor version release."
+            )
+            sys.exit(1)
         
         if patch > 0:
             # For patch releases we will update all version entries with the same major.minor version as the module patch we just released


### PR DESCRIPTION
We should only update the minor versions of modules when Valkey is at a minor version.