### PR TITLE
Add Bundle Search Test Functionality

### DIFF
--- a/.test/tests/valkey-integration-tests/run.sh
+++ b/.test/tests/valkey-integration-tests/run.sh
@@ -73,6 +73,9 @@ for repo in "${repos[@]}"; do
         elif [[ "$repo" == "valkey-json" ]]; then
             echo "Cloning $repo from version tag $JSON_TAG"
             git clone -b "$JSON_TAG" --depth=1 "https://github.com/valkey-io/$repo.git" "./$repo"
+        elif [[ "$repo" == "valkey-search" ]]; then
+            echo "Cloning $repo from unstable branch"
+            git clone -b unstable --depth=1 "https://github.com/valkey-io/$repo.git" "./$repo"
         else
             echo "Cloning $repo from main branch"
             git clone --depth=1 "https://github.com/valkey-io/$repo.git" "./$repo"
@@ -233,36 +236,47 @@ run_tests() {
             cd integration
             export PYTHONPATH="$(pwd)/valkeytestframework:$(pwd)"
             export SKIPLOGCLEAN=1
-            
-            # Exclude tests incompatible with external server mode and only test core functionality:
-            # - Module loading tests: require control over module loading
-            # - Cluster tests: require multi-node cluster setup
-            # - RDB/persistence tests: require save/load control
-            # - Consistency/replication tests: require primary/replica setup
-            # - Cross-module tests: require specific module loading order
-            # - Debug mode tests: require FT._DEBUG commands not available in bundle
-            # - Eviction/OOM tests: modify memory settings that contaminate subsequent tests
-            # - Initial scan tests: require control over server startup
-            # - Metrics tests: check cumulative metrics that don't reset between tests
-            # - Config tests: check configs that differ in bundle vs local build
-            # - ACL tests: require ACL configuration control
+
+            # List of test files compatible with external server mode in order to test core functionality of Search
+            TEST_FILES=""
+            for test in \
+                test_aggregate_metrics.py \
+                test_expired.py \
+                test_filter_expressions.py \
+                test_ft_create.py \
+                test_ft_dropindex.py \
+                test_ft_internal_update.py \
+                test_fulltext.py \
+                test_fulltext_space_performance.py \
+                test_info.py \
+                test_json_operations.py \
+                test_multidb_search.py \
+                test_multi_lua.py \
+                test_non_vector.py \
+                test_query_parser.py \
+                test_reclaimable_memory.py \
+                test_vss_basic.py
+            do
+                if [ -f "$test" ]; then
+                    TEST_FILES="$TEST_FILES $test"
+                fi
+            done
+
+            # Exclude specific incompatible tests within the files
             SKIP_TESTS="not ("
-            SKIP_TESTS+="test_module_loaded or CME or cluster or Cluster"
-            SKIP_TESTS+=" or saverestore or skip_index_load or rdb_load or multidb_rdb"
-            SKIP_TESTS+=" or consistency or fanout or info_primary"
-            SKIP_TESTS+=" or TestJsonBackfill or cross_module or cancel or copy"
-            SKIP_TESTS+=" or debug or postfilter or inflight_blocking or versioning"
-            SKIP_TESTS+=" or eviction or oom or setup_test0"
-            SKIP_TESTS+=" or skipinitialscan or TestSkipInitialScan or dbnum or singleslot"
-            SKIP_TESTS+=" or TestCreateNonVectorIndexes or TestAppMetrics"
+            SKIP_TESTS+="Cluster or cluster or CME"
+            SKIP_TESTS+=" or TestFullTextDebugMode or debug"
+            SKIP_TESTS+=" or TestAppMetrics or TestCreateNonVectorIndexes"
+            SKIP_TESTS+=" or replica or acl"
+            SKIP_TESTS+=" or setup_test0 or rdb or backfill"
             SKIP_TESTS+=" or test_query_string_bytes_limit or test_tag_min_prefix_length_config"
             SKIP_TESTS+=" or test_text_search or test_suffix_search or test_text_size_estimation"
-            SKIP_TESTS+=" or acl"
+            SKIP_TESTS+=" or test_reclaimable_memory"
             SKIP_TESTS+=")"
 
             python -m pytest --log-cli-level=INFO --capture=sys --cache-clear -v \
                 -k "$SKIP_TESTS" \
-                test_*.py
+                $TEST_FILES
 
             local pytest_exit_code=$?
             cleanup_container

--- a/.test/tests/valkey-integration-tests/run.sh
+++ b/.test/tests/valkey-integration-tests/run.sh
@@ -73,9 +73,6 @@ for repo in "${repos[@]}"; do
         elif [[ "$repo" == "valkey-json" ]]; then
             echo "Cloning $repo from version tag $JSON_TAG"
             git clone -b "$JSON_TAG" --depth=1 "https://github.com/valkey-io/$repo.git" "./$repo"
-        elif [[ "$repo" == "valkey-search" ]]; then
-            echo "Cloning $repo from unstable branch"
-            git clone -b unstable --depth=1 "https://github.com/valkey-io/$repo.git" "./$repo"
         else
             echo "Cloning $repo from main branch"
             git clone --depth=1 "https://github.com/valkey-io/$repo.git" "./$repo"

--- a/.test/tests/valkey-integration-tests/run.sh
+++ b/.test/tests/valkey-integration-tests/run.sh
@@ -216,26 +216,60 @@ run_tests() {
             fi
             ;;
         "Search")
-            echo "CANT RUN SEARCH TESTS UNTIL BUNDLE IS UPDATED WITH NEW SEARCH PATCH"
-    
-            # setup_test_framework "integration/valkey-test-framework"
-                    
-            # pip install -r integration/valkey-test-framework/requirements.txt
-            # pip install absl-py numpy 
+            setup_test_framework "integration/valkeytestframework"
 
-            # docker run -d -p $VALKEY_PORT:6379 --name "$CONTAINER_NAME" "$image" \
-            #    valkey-server \
-            #       --enable-debug-command yes \
-            #       --protected-mode no >/dev/null 2>&1
-            # sleep 3
+            docker run -d -p $VALKEY_PORT:6379 --name "$CONTAINER_NAME" "$image" \
+                valkey-server \
+                --save "" \
+                --enable-debug-command yes \
+                --enable-module-command yes \
+                --protected-mode no >/dev/null 2>&1
+            sleep 3
 
-            # cd integration
-            # export PYTHONPATH="$(pwd)/valkeytestframework:$(pwd)"
-            # export SKIPLOGCLEAN=1
-            # python -m pytest --log-cli-level=INFO --capture=sys --cache-clear -v -k "not (test_module_loaded or CME or cluster)" test_*.py
-            # local pytest_exit_code=$?
-            # cleanup_container
-            # return $pytest_exit_code
+            export VALKEY_SERVER_PATH="valkey-server"
+            export MODULE_PATH="/usr/lib/valkey/modules/libsearch.so"
+            export JSON_MODULE_PATH="/usr/lib/valkey/modules/libjson.so"
+
+            cd integration
+            export PYTHONPATH="$(pwd)/valkeytestframework:$(pwd)"
+            export SKIPLOGCLEAN=1
+            
+            # Exclude tests incompatible with external server mode and only test core functionality:
+            # - Module loading tests: require control over module loading
+            # - Cluster tests: require multi-node cluster setup
+            # - RDB/persistence tests: require save/load control
+            # - Consistency/replication tests: require primary/replica setup
+            # - Cross-module tests: require specific module loading order
+            # - Debug mode tests: require FT._DEBUG commands not available in bundle
+            # - Eviction/OOM tests: modify memory settings that contaminate subsequent tests
+            # - Initial scan tests: require control over server startup
+            # - Metrics tests: check cumulative metrics that don't reset between tests
+            # - Config tests: check configs that differ in bundle vs local build
+            # - ACL tests: require ACL configuration control
+            SKIP_TESTS="not ("
+            SKIP_TESTS+="test_module_loaded or CME or cluster or Cluster"
+            SKIP_TESTS+=" or saverestore or skip_index_load or rdb_load or multidb_rdb"
+            SKIP_TESTS+=" or consistency or fanout or info_primary"
+            SKIP_TESTS+=" or TestJsonBackfill or cross_module or cancel or copy"
+            SKIP_TESTS+=" or debug or postfilter or inflight_blocking or versioning"
+            SKIP_TESTS+=" or eviction or oom or setup_test0"
+            SKIP_TESTS+=" or skipinitialscan or TestSkipInitialScan or dbnum or singleslot"
+            SKIP_TESTS+=" or TestCreateNonVectorIndexes or TestAppMetrics"
+            SKIP_TESTS+=" or test_query_string_bytes_limit or test_tag_min_prefix_length_config"
+            SKIP_TESTS+=" or test_text_search or test_suffix_search or test_text_size_estimation"
+            SKIP_TESTS+=" or acl"
+            SKIP_TESTS+=")"
+
+            python -m pytest --log-cli-level=INFO --capture=sys --cache-clear -v \
+                -k "$SKIP_TESTS" \
+                test_*.py
+
+            local pytest_exit_code=$?
+            cleanup_container
+            cd ..
+            if [ $pytest_exit_code -ne 0 ]; then
+                false
+            fi
             ;;
         "LDAP")
             echo "VALKEY LDAP DOESN'T USE VALKEY TEST FRAMEWORK"
@@ -261,7 +295,7 @@ overall_success=true
 run_tests "Valkey" "./valkey" || overall_success=false
 run_tests "JSON" "./valkey-json" || overall_success=false
 run_tests "Bloom" "./valkey-bloom" || overall_success=false
-# run_tests "Search" "./valkey-search" || overall_success=false
+run_tests "Search" "./valkey-search" || overall_success=false
 # run_tests "LDAP" "./valkey-ldap" || overall_success=false
 
 echo "=== Integration Tests Complete ==="


### PR DESCRIPTION
This PR adds valkey-search integration tests to the run.sh CI test script and runs them against the valkey-bundle Docker container in external server mode (`VALKEY_EXTERNAL_SERVER=true`).

A PR has been opened to the search repo as well to support this: https://github.com/valkey-io/valkey-search/pull/908

I have explicitly listed 16 test files that are compatible with external server mode and test the core functionality of Valkey Search. I think this is more optimal than running all tests and skipping incompatible ones since then we don't have to monitor the new tests that Search will add that may not run against external servers or will need multiple servers to be running. The reason we skipped some tests is because many test files in valkey-search require cluster mode, replica setups, or internal server management that aren't supported when testing against an external container. Regardless these tests are very comprehensive in making sure search works with the bundle. 

Additionally, we still currently run against the main branch of Search for all search versions because I need to check back porting for the external server fix after the PR I linked above is merged in. This is fine for now we can run all tests against the main branch of Search. In the near future i'll open a new PR so that each of the tests will be run against it's respective cloned branch in CI (1.0, 1.2 etc). That's why i have included the check in this PR to make sure the tests we are running exist in the branch first (since search versions before 1.2 won't include full text capabilities/tests)