### PR TITLE
Skip a Valkey Test that isn't compatible with our server. 

### DIFF
--- a/.test/tests/valkey-integration-tests/run.sh
+++ b/.test/tests/valkey-integration-tests/run.sh
@@ -140,6 +140,7 @@ run_tests() {
             --skiptest "Extended Redis Compatibility config" \
             --skiptest "CLIENT LIST with IPv6 filter" \
             --skiptest "CLIENT LIST with IPv6 negative filter" \
+            --skiptest "CLIENT KILL with IPv6 filter" \
             ;;
         "JSON")
             setup_test_framework "tst/integration/valkeytests"


### PR DESCRIPTION
The CLIENT KILL with IPv6 filter test uses start_server with overrides {bind {127.0.0.1 ::1}}, which is ignored in external server mode. The test then attempts to connect to ::1, which fails with an I/O error since the container isn't bound to IPv6. We should skip this test.