### PR TITLE
Use PAT Token so CI triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "**/Dockerfile"
   workflow_dispatch:
+  workflow_call:
 
 permissions:
   id-token: write

--- a/.github/workflows/update-files.yml
+++ b/.github/workflows/update-files.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout Valkey-Bundle
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          token: ${{ secrets.VALKEY_BUNDLE_PAT_FOR_PR }}
 
       - name: Configure Git
         run: |
@@ -69,7 +71,7 @@ jobs:
           if git diff --staged --quiet; then
             echo "pushed=false" >> $GITHUB_OUTPUT
           else
-            git commit -m "Update unstable module versions"
+            git commit -m "Automated update for unstable module versions"
             git push
             echo "pushed=true" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/update-files.yml
+++ b/.github/workflows/update-files.yml
@@ -26,6 +26,8 @@ jobs:
     name: Update Unstable Module Versions
     if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.version == 'unstable' && inputs.component == 'valkey')
     runs-on: ubuntu-latest
+    outputs:
+      versions-updated: ${{ steps.commit-push.outputs.versions-updated }}
     steps:
       - name: Checkout Valkey-Bundle
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -69,20 +71,17 @@ jobs:
         run: |
           git add versions.json unstable/ dockerhub-description.md
           if git diff --staged --quiet; then
-            echo "pushed=false" >> $GITHUB_OUTPUT
+            echo "versions-updated=false" >> $GITHUB_OUTPUT
           else
             git commit -m "Automated update for unstable module versions"
             git push
-            echo "pushed=true" >> $GITHUB_OUTPUT
+            echo "versions-updated=true" >> $GITHUB_OUTPUT
           fi
-
-    outputs:
-      pushed: ${{ steps.commit-push.outputs.pushed }}
 
   trigger-ci:
     name: Trigger CI
     needs: update-unstable
-    if: needs.update-unstable.outputs.pushed != 'true'
+    if: needs.update-unstable.outputs.versions-updated != 'true'
     uses: ./.github/workflows/ci.yml
     secrets: inherit
 

--- a/.github/workflows/update-files.yml
+++ b/.github/workflows/update-files.yml
@@ -76,11 +76,15 @@ jobs:
             echo "pushed=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Trigger CI
-        if: steps.commit-push.outputs.pushed != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run ci.yml --ref mainline
+    outputs:
+      pushed: ${{ steps.commit-push.outputs.pushed }}
+
+  trigger-ci:
+    name: Trigger CI
+    needs: update-unstable
+    if: needs.update-unstable.outputs.pushed != 'true'
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit
 
   update-files:
     name: Update Files and Create Pull Request


### PR DESCRIPTION
**Changes in this PR**
- PRs pushed by GitHub won't automatically trigger the CI so we have to use our PAT Token
- Changed the CI trigger from a github API call to a workflow call