### PR TITLE
Add version input to CI workflow and filter strategy matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,17 @@ on:
     paths:
       - "**/Dockerfile"
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Versions to build (space-separated, e.g. "unstable" or "8.1 unstable")'
+        required: true
+        type: string
   workflow_call:
+    inputs:
+      version:
+        description: 'Versions to build (space-separated, e.g. "unstable" or "8.1 unstable")'
+        required: true
+        type: string
 
 permissions:
   id-token: write
@@ -49,6 +59,12 @@ jobs:
             else
               strategy='{"fail-fast": false, "matrix": {"include": []}}'
             fi
+          fi
+
+          # For workflow_call or workflow_dispatch with version input, filter to requested versions
+          if [[ "${{ github.event_name }}" == "workflow_call" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            versions_regex=$(echo "${{ inputs.version }}" | tr ' ' '|')
+            strategy=$(jq -c --arg versions "$versions_regex" '{"fail-fast": .["fail-fast"],"matrix":{"include":[ .matrix.include[]|select(.meta.entries[0].directory | test($versions))]}}' <<<"$strategy")
           fi
 
           echo "strategy=$(jq -c . <<<"$strategy")" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/update-files.yml
+++ b/.github/workflows/update-files.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   update-unstable:
     name: Update Unstable Module Versions
-    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.version == 'unstable' && inputs.component == 'valkey')
+    if: (github.event_name == 'schedule' && github.repository_owner == 'valkey-io') || (github.event_name == 'workflow_dispatch' && inputs.version == 'unstable' && inputs.component == 'valkey')
     runs-on: ubuntu-latest
     outputs:
       versions-updated: ${{ steps.commit-push.outputs.versions-updated }}
@@ -85,6 +85,8 @@ jobs:
     needs: update-unstable
     if: needs.update-unstable.outputs.versions-updated != 'true'
     uses: ./.github/workflows/ci.yml
+    with:
+      version: unstable
     secrets: inherit
 
   update-files:


### PR DESCRIPTION
- Add required 'version' input (space-separated) to workflow_call and workflow_dispatch in ci.yml
- Filter generate-jobs strategy matrix when triggered via call/dispatch
- Pass version: unstable from update-files.yml trigger-ci job
- Restrict schedule trigger to valkey-io org only