### PR TITLE
Fix CI version filter for schedule-triggered workflow_call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,8 @@ jobs:
             fi
           fi
 
-          # For workflow_call or workflow_dispatch with version input, filter to requested versions
-          if [[ "${{ github.event_name }}" == "workflow_call" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          # Filter strategy to only build requested versions for workflow_call, workflow_dispatch, and schedule triggers
+          if [[ "${{ github.event_name }}" == "workflow_call" || "${{ github.event_name }}" == "workflow_dispatch" || "${{ github.event_name }}" == "schedule" ]]; then
             versions_regex=$(echo "${{ inputs.version }}" | tr ' ' '|')
             strategy=$(jq -c --arg versions "$versions_regex" '{"fail-fast": .["fail-fast"],"matrix":{"include":[ .matrix.include[]|select(.meta.entries[0].directory | test($versions))]}}' <<<"$strategy")
           fi


### PR DESCRIPTION
When `update-files.yml` calls `ci.yml` via `workflow_call` during a schedule event, `github.event_name` is `schedule` (propagated from the caller), not `workflow_call`. This means the version filter condition never matched, causing all versions to be built instead of just the requested ones (e.g. `unstable`).

**Fix:** Add `schedule` to the event name check so the version filter applies correctly.

**Before:** Scheduled trigger-ci built all 8 matrix entries (8.1, 9.0, 9.1, unstable × debian/alpine).
**After:** Scheduled trigger-ci with `version: unstable` builds only 2 entries (unstable × debian/alpine).

Ref: https://github.com/valkey-io/valkey-bundle/actions/runs/23523934944