### PR TITLE
Clone the specific valkey-bloom version for tests instead of unstable

### DIFF
--- a/.test/tests/valkey-integration-tests/run.sh
+++ b/.test/tests/valkey-integration-tests/run.sh
@@ -76,6 +76,9 @@ for repo in "${repos[@]}"; do
         elif [[ "$repo" == "valkey-json" ]]; then
             echo "Cloning $repo from version tag $JSON_TAG"
             git clone -b "$JSON_TAG" --depth=1 "https://github.com/valkey-io/$repo.git" "./$repo"
+        elif [[ "$repo" == "valkey-bloom" ]]; then
+            echo "Cloning $repo from version tag $BLOOM_TAG"
+            git clone -b "$BLOOM_TAG" --depth=1 "https://github.com/valkey-io/$repo.git" "./$repo"
         else
             echo "Cloning $repo from main branch"
             git clone --depth=1 "https://github.com/valkey-io/$repo.git" "./$repo"


### PR DESCRIPTION
This should fix these failures in the daily: https://github.com/valkey-io/valkey-bundle/actions/runs/24759432798

New functionality was added to the unstable branch of valkey-bloom along with it's corresponding tests cases. These failures are due to how we are testing functionality in version valkey-bloom 1.0.1 against the tests in unstable. We'll now clone the specific version so we'll test branch 1.0.1 against tests in 1.0.1