### PR TITLE
Strip [bot] suffix from github.actor when constructing Docker image tags.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,13 +96,10 @@ jobs:
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
-      - name: Set lowercase actor name
-        run: echo "ACTOR_LOWER=$(echo '${{ github.actor }}' | tr '[:upper:]' '[:lower:]' | sed 's/\[bot\]$//')" >> $GITHUB_ENV
-
       - name: Set DOCKER_REPO_NAME dynamically
         run: |
           if [[ "${{ env.IS_PULL }}" == "true" || "${{ env.HAS_SECRETS }}" != "true" ]]; then
-            echo "DOCKER_REPO_NAME=${{ env.ACTOR_LOWER }}/valkey-bundle" >> $GITHUB_ENV
+            echo "DOCKER_REPO_NAME=valkeytest/valkey-bundle" >> $GITHUB_ENV
           else
             echo "DOCKER_REPO_NAME=${{ secrets.DOCKERHUB_ACCOUNT }}/valkey-bundle" >> $GITHUB_ENV
           fi
@@ -110,7 +107,7 @@ jobs:
       - name: Set GHCR_REPO_NAME dynamically
         run: |
           if [[ "${{ env.IS_PULL }}" == "true" || "${{ env.HAS_SECRETS }}" != "true" ]]; then
-            echo "GHCR_REPO_NAME=${{ env.ACTOR_LOWER }}/valkey-bundle" >> $GITHUB_ENV
+            echo "GHCR_REPO_NAME=valkeytest/valkey-bundle" >> $GITHUB_ENV
           else
             echo "GHCR_REPO_NAME=${{ github.repository_owner }}/valkey-bundle" >> $GITHUB_ENV
           fi
@@ -118,7 +115,7 @@ jobs:
       - name: Set ECR_REPO_PATH dynamically
         run: |
           if [[ "${{ env.IS_PULL }}" == "true" || "${{ env.HAS_SECRETS }}" != "true" ]]; then
-            echo "ECR_REPO_PATH=${{ env.ACTOR_LOWER }}/valkey-bundle" >> $GITHUB_ENV
+            echo "ECR_REPO_PATH=valkeytest/valkey-bundle" >> $GITHUB_ENV
           else
             echo "ECR_REPO_PATH=${{ secrets.ECR_REGISTRY_ALIAS }}/valkey-bundle" >> $GITHUB_ENV
           fi
@@ -284,13 +281,10 @@ jobs:
     outputs:
       has-secrets: ${{ steps.output-has-secrets.outputs.has-secrets }}
     steps:
-      - name: Set lowercase actor name
-        run: echo "ACTOR_LOWER=$(echo '${{ github.actor }}' | tr '[:upper:]' '[:lower:]' | sed 's/\[bot\]$//')" >> $GITHUB_ENV
-
       - name: Set DOCKER_REPO_NAME dynamically
         run: |
           if [[ "${{ env.IS_PULL }}" == "true" || "${{ env.HAS_SECRETS }}" != "true" ]]; then
-            echo "DOCKER_REPO_NAME=${{ env.ACTOR_LOWER }}/valkey-bundle" >> $GITHUB_ENV
+            echo "DOCKER_REPO_NAME=valkeytest/valkey-bundle" >> $GITHUB_ENV
           else
             echo "DOCKER_REPO_NAME=${{ secrets.DOCKERHUB_ACCOUNT }}/valkey-bundle" >> $GITHUB_ENV
           fi
@@ -298,7 +292,7 @@ jobs:
       - name: Set GHCR_REPO_NAME dynamically
         run: |
           if [[ "${{ env.IS_PULL }}" == "true" || "${{ env.HAS_SECRETS }}" != "true" ]]; then
-            echo "GHCR_REPO_NAME=${{ env.ACTOR_LOWER }}/valkey-bundle" >> $GITHUB_ENV
+            echo "GHCR_REPO_NAME=valkeytest/valkey-bundle" >> $GITHUB_ENV
           else
             echo "GHCR_REPO_NAME=${{ github.repository_owner }}/valkey-bundle" >> $GITHUB_ENV
           fi
@@ -306,7 +300,7 @@ jobs:
       - name: Set ECR_REPO_PATH dynamically
         run: |
           if [[ "${{ env.IS_PULL }}" == "true" || "${{ env.HAS_SECRETS }}" != "true" ]]; then
-            echo "ECR_REPO_PATH=${{ env.ACTOR_LOWER }}/valkey-bundle" >> $GITHUB_ENV
+            echo "ECR_REPO_PATH=valkeytest/valkey-bundle" >> $GITHUB_ENV
           else
             echo "ECR_REPO_PATH=${{ secrets.ECR_REGISTRY_ALIAS }}/valkey-bundle" >> $GITHUB_ENV
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
       - name: Set lowercase actor name
-        run: echo "ACTOR_LOWER=$(echo '${{ github.actor }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+        run: echo "ACTOR_LOWER=$(echo '${{ github.actor }}' | tr '[:upper:]' '[:lower:]' | sed 's/\[bot\]$//')" >> $GITHUB_ENV
 
       - name: Set DOCKER_REPO_NAME dynamically
         run: |
@@ -285,7 +285,7 @@ jobs:
       has-secrets: ${{ steps.output-has-secrets.outputs.has-secrets }}
     steps:
       - name: Set lowercase actor name
-        run: echo "ACTOR_LOWER=$(echo '${{ github.actor }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+        run: echo "ACTOR_LOWER=$(echo '${{ github.actor }}' | tr '[:upper:]' '[:lower:]' | sed 's/\[bot\]$//')" >> $GITHUB_ENV
 
       - name: Set DOCKER_REPO_NAME dynamically
         run: |


### PR DESCRIPTION
Strip [bot] suffix from github.actor when constructing Docker image tags. GitHub Apps like valkey-ops[bot] produce invalid Docker references due to square brackets being illegal in tag names.