### PR TITLE
Fix Alpine Bundle builds and release versions

### DIFF
--- a/8.1/alpine/Dockerfile
+++ b/8.1/alpine/Dockerfile
@@ -16,12 +16,12 @@ RUN set -eux; \
 	        git                   \
 	        curl                  \
 	        clang                 \
-	        clang19-dev           \
+	        clang-dev             \
 	        gtest-dev             \
 	        ninja-build           \
 	        ninja-is-really-ninja \
 	        openssl-dev           \
-	        clang19-extra-tools   \
+	        clang-extra-tools     \
 	        linux-headers         \
 	        bash                  \
                 pkgconfig             \

--- a/9.0/alpine/Dockerfile
+++ b/9.0/alpine/Dockerfile
@@ -16,12 +16,12 @@ RUN set -eux; \
 	        git                   \
 	        curl                  \
 	        clang                 \
-	        clang19-dev           \
+	        clang-dev             \
 	        gtest-dev             \
 	        ninja-build           \
 	        ninja-is-really-ninja \
 	        openssl-dev           \
-	        clang19-extra-tools   \
+	        clang-extra-tools     \
 	        linux-headers         \
 	        bash                  \
                 pkgconfig             \

--- a/9.1/alpine/Dockerfile
+++ b/9.1/alpine/Dockerfile
@@ -16,12 +16,12 @@ RUN set -eux; \
 	        git                   \
 	        curl                  \
 	        clang                 \
-	        clang19-dev           \
+	        clang-dev             \
 	        gtest-dev             \
 	        ninja-build           \
 	        ninja-is-really-ninja \
 	        openssl-dev           \
-	        clang19-extra-tools   \
+	        clang-extra-tools     \
 	        linux-headers         \
 	        bash                  \
                 pkgconfig             \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -16,12 +16,12 @@ RUN set -eux; \
 	        git                   \
 	        curl                  \
 	        clang                 \
-	        clang19-dev           \
+	        clang-dev             \
 	        gtest-dev             \
 	        ninja-build           \
 	        ninja-is-really-ninja \
 	        openssl-dev           \
-	        clang19-extra-tools   \
+	        clang-extra-tools     \
 	        linux-headers         \
 	        bash                  \
                 pkgconfig             \

--- a/dockerhub-description.md
+++ b/dockerhub-description.md
@@ -12,12 +12,12 @@
 
 
 ## Official releases
-- [`9.1.1`, `9.1`, `9`, `latest`, `9.1.1-trixie`, `9.1-trixie`, `9-trixie`, `trixie`](https://github.com/valkey-io/valkey-bundle/blob/mainline/9.1/debian/Dockerfile)
-- [`9.1.1-alpine`, `9.1-alpine`, `9-alpine`, `alpine`](https://github.com/valkey-io/valkey-bundle/blob/mainline/9.1/alpine/Dockerfile)
+- [`9.1.2`, `9.1`, `9`, `latest`, `9.1.2-trixie`, `9.1-trixie`, `9-trixie`, `trixie`](https://github.com/valkey-io/valkey-bundle/blob/mainline/9.1/debian/Dockerfile)
+- [`9.1.2-alpine`, `9.1-alpine`, `9-alpine`, `alpine`](https://github.com/valkey-io/valkey-bundle/blob/mainline/9.1/alpine/Dockerfile)
 - [`9.0.5`, `9.0`, `9.0.5-trixie`, `9.0-trixie`](https://github.com/valkey-io/valkey-bundle/blob/mainline/9.0/debian/Dockerfile)
 - [`9.0.5-alpine`, `9.0-alpine`](https://github.com/valkey-io/valkey-bundle/blob/mainline/9.0/alpine/Dockerfile)
-- [`8.1.10`, `8.1`, `8`, `8.1.10-trixie`, `8.1-trixie`, `8-trixie`](https://github.com/valkey-io/valkey-bundle/blob/mainline/8.1/debian/Dockerfile)
-- [`8.1.10-alpine`, `8.1-alpine`, `8-alpine`](https://github.com/valkey-io/valkey-bundle/blob/mainline/8.1/alpine/Dockerfile)
+- [`8.1.9`, `8.1`, `8`, `8.1.9-trixie`, `8.1-trixie`, `8-trixie`](https://github.com/valkey-io/valkey-bundle/blob/mainline/8.1/debian/Dockerfile)
+- [`8.1.9-alpine`, `8.1-alpine`, `8-alpine`](https://github.com/valkey-io/valkey-bundle/blob/mainline/8.1/alpine/Dockerfile)
 ## Latest unstable
 - [`unstable`, `unstable-trixie`](https://github.com/valkey-io/valkey-bundle/blob/mainline/unstable/debian/Dockerfile)
 - [`unstable-alpine`](https://github.com/valkey-io/valkey-bundle/blob/mainline/unstable/alpine/Dockerfile)
@@ -33,9 +33,9 @@ This image is built on top of the official Valkey base image and simplifies depl
 | valkey-bundle | valkey | valkey-json | valkey-bloom | valkey-search | valkey-ldap |
 |-------------------------|-------------|-------------|--------------|---------------|---------------|
 | unstable | unstable | [unstable](https://github.com/valkey-io/valkey-json/tree/unstable) | [unstable](https://github.com/valkey-io/valkey-bloom/tree/unstable) | [main](https://github.com/valkey-io/valkey-search/tree/main) | [main](https://github.com/valkey-io/valkey-ldap/tree/main) |
-| 9.1.1 |[9.1.1](https://github.com/valkey-io/valkey/releases/tag/9.1.1) | [1.0.2](https://github.com/valkey-io/valkey-json/releases/tag/1.0.2)| [1.0.1](https://github.com/valkey-io/valkey-bloom/releases/tag/1.0.1)| [1.2.1](https://github.com/valkey-io/valkey-search/releases/tag/1.2.1) | [1.1.1](https://github.com/valkey-io/valkey-ldap/releases/tag/1.1.1) |
+| 9.1.2 |[9.1.1](https://github.com/valkey-io/valkey/releases/tag/9.1.1) | [1.0.2](https://github.com/valkey-io/valkey-json/releases/tag/1.0.2)| [1.0.1](https://github.com/valkey-io/valkey-bloom/releases/tag/1.0.1)| [1.2.1](https://github.com/valkey-io/valkey-search/releases/tag/1.2.1) | [1.1.1](https://github.com/valkey-io/valkey-ldap/releases/tag/1.1.1) |
 | 9.0.5 |[9.0.5](https://github.com/valkey-io/valkey/releases/tag/9.0.5) | [1.0.2](https://github.com/valkey-io/valkey-json/releases/tag/1.0.2)| [1.0.1](https://github.com/valkey-io/valkey-bloom/releases/tag/1.0.1)| [1.0.3](https://github.com/valkey-io/valkey-search/releases/tag/1.0.3) | [1.0.1](https://github.com/valkey-io/valkey-ldap/releases/tag/1.0.1) |
-| 8.1.10 |[8.1.9](https://github.com/valkey-io/valkey/releases/tag/8.1.9) | [1.0.2](https://github.com/valkey-io/valkey-json/releases/tag/1.0.2)| [1.0.1](https://github.com/valkey-io/valkey-bloom/releases/tag/1.0.1)| [1.0.3](https://github.com/valkey-io/valkey-search/releases/tag/1.0.3) | [1.0.1](https://github.com/valkey-io/valkey-ldap/releases/tag/1.0.1) |
+| 8.1.9 |[8.1.9](https://github.com/valkey-io/valkey/releases/tag/8.1.9) | [1.0.2](https://github.com/valkey-io/valkey-json/releases/tag/1.0.2)| [1.0.1](https://github.com/valkey-io/valkey-bloom/releases/tag/1.0.1)| [1.0.3](https://github.com/valkey-io/valkey-search/releases/tag/1.0.3) | [1.0.1](https://github.com/valkey-io/valkey-ldap/releases/tag/1.0.1) |
 
 
 # Security

--- a/unstable/alpine/Dockerfile
+++ b/unstable/alpine/Dockerfile
@@ -16,12 +16,12 @@ RUN set -eux; \
 	        git                   \
 	        curl                  \
 	        clang                 \
-	        clang19-dev           \
+	        clang-dev             \
 	        gtest-dev             \
 	        ninja-build           \
 	        ninja-is-really-ninja \
 	        openssl-dev           \
-	        clang19-extra-tools   \
+	        clang-extra-tools     \
 	        linux-headers         \
 	        bash                  \
                 pkgconfig             \

--- a/versions.json
+++ b/versions.json
@@ -23,7 +23,7 @@
     }
   },
   "8.1": {
-    "version": "8.1.10",
+    "version": "8.1.9",
     "valkey-server": {
       "version": "8.1.9"
     },
@@ -69,7 +69,7 @@
     }
   },
   "9.1": {
-    "version": "9.1.1",
+    "version": "9.1.2",
     "valkey-server": {
       "version": "9.1.1"
     },


### PR DESCRIPTION
The new stable Valkey images moved from Alpine 3.23 to 3.24. Bundle hardcoded Clang 19 packages, which Alpine 3.24 does not provide. Consequently, every stable Alpine build failed during `apk add`.

The release aggregation also processed the `8.1.9` event twice, while retaining the already-published Bundle version `9.1.1` for new content.

This branch starts from the exact head of upstream PR #119.
